### PR TITLE
Report incoming IP address when a connection comes in

### DIFF
--- a/include/tr_socket.h
+++ b/include/tr_socket.h
@@ -37,7 +37,9 @@
 
 #include <stdlib.h>
 #include <poll.h> // for nfds_t
+#include <sys/socket.h>
 
 nfds_t tr_sock_listen_all(unsigned int port, int *fd_out, nfds_t max_fd);
+int tr_sock_accept(int sock);
 
 #endif //TRUST_ROUTER_TR_SOCKET_H

--- a/mon/mons.c
+++ b/mon/mons.c
@@ -225,8 +225,8 @@ int mons_accept(MONS_INSTANCE *mons, int listen)
   int conn=-1;
   int pid=-1;
 
-  if (0 > (conn = accept(listen, NULL, NULL))) {
-    perror("Error from monitoring interface accept()");
+  if (0 > (conn = tr_sock_accept(listen))) {
+    tr_err("mons_accept: Error accepting connection");
     return 1;
   }
 

--- a/tid/tids.c
+++ b/tid/tids.c
@@ -399,8 +399,8 @@ int tids_accept(TIDS_INSTANCE *tids, int listen)
   int pipe_fd[2];
   struct tid_process tp = {0};
 
-  if (0 > (conn = accept(listen, NULL, NULL))) {
-    perror("Error from TIDS Server accept()");
+  if (0 > (conn = tr_sock_accept(listen))) {
+    tr_err("tids_accept: Error accepting connection");
     return 1;
   }
 

--- a/tr/tr_trp.c
+++ b/tr/tr_trp.c
@@ -114,7 +114,7 @@ static int tr_trps_gss_handler(gss_name_t client_name, gss_buffer_t gss_name,
 
   tr_debug("tr_trps_gss_handler()");
 
-  if ((!client_name) || (!gss_name) || (!trps) || (!cfg_mgr)) {
+  if ((!client_name) || (!trps) || (!cfg_mgr)) {
     tr_debug("tr_trps_gss_handler: Bad parameters.");
     return -1;
   }
@@ -881,7 +881,11 @@ void tr_config_changed(TR_CFG *new_cfg, void *cookie)
     tr_debug("tr_config_changed: freeing tr->mons->authorized_gss_names");
     tr_gss_names_free(tr->mons->authorized_gss_names);
   }
-  tr->mons->authorized_gss_names = tr_gss_names_dup(tr->mons, new_cfg->internal->monitoring_credentials);
+  if (new_cfg->internal->monitoring_credentials != NULL) {
+    tr->mons->authorized_gss_names = tr_gss_names_dup(tr->mons, new_cfg->internal->monitoring_credentials);
+  } else {
+    tr->mons->authorized_gss_names = tr_gss_names_new(tr->mons);
+  }
   if (tr->mons->authorized_gss_names == NULL) {
     tr_err("tr_config_changed: Error configuring monitoring credentials");
   }

--- a/trp/trp_conn.c
+++ b/trp/trp_conn.c
@@ -40,6 +40,7 @@
 
 #include <tr_debug.h>
 #include <trp_internal.h>
+#include <tr_socket.h>
 
 /* Threading note: mutex lock is only used for protecting get_status() and set_status().
  * If needed, locking for other operations (notably adding/removing connections) must be managed
@@ -344,10 +345,10 @@ TRP_CONNECTION *trp_connection_accept(TALLOC_CTX *mem_ctx, int listen, TR_NAME *
   int conn_fd=-1;
   TRP_CONNECTION *conn=NULL;
 
-  conn_fd = accept(listen, NULL, NULL);
+  conn_fd = tr_sock_accept(listen);
 
   if (0 > conn_fd) {
-    tr_notice("trp_connection_accept: accept() returned error.");
+    tr_notice("trp_connection_accept: Error accepting connection.");
     return NULL;
   }
   conn=trp_connection_new(mem_ctx);


### PR DESCRIPTION
Resolves #6. 

This prints the IP address in the log when a connection comes in.

It also updates the allowed monitoring credentials after a reconfiguration. That should not have been part of this commit, but it snuck in. Oops!