### PR TITLE
Include GSS transaction code in libtr_tid and ensure the library is linkable when building

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -129,6 +129,7 @@ tests_t_libtr_tid_la_SOURCES = tests/t_libtr_tid_la.c
 tests_t_libtr_tid_la_LDADD = $(lib_LTLIBRARIES)
 
 tr_trust_router_SOURCES = \
+    $(common_srcs) \
     tr/tr_main.c \
     tr/tr.c \
     tr/tr_event.c \
@@ -138,14 +139,12 @@ tr_trust_router_SOURCES = \
     tr/tr_trp.c \
     tr/tr_trp_mons.c \
     tr/tr_mon.c \
-    $(gss_srcs) \
-    $(tid_srcs) \
     $(trp_srcs) \
-    $(common_srcs) \
+    $(gss_srcs) \
     $(mons_srcs)
 
 tr_trust_router_LDFLAGS = $(AM_LDFLAGS) -levent_pthreads -pthread
-tr_trust_router_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
+tr_trust_router_LDADD = gsscon/libgsscon.la $(GLIB_LIBS) $(lib_LTLIBRARIES)
 
 tr_trpc_SOURCES = \
     tr/trpc_main.c \
@@ -203,15 +202,14 @@ trp_test_ptbl_test_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 trp_test_ptbl_test_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tidc_SOURCES = \
-    tid/example/tidc_main.c \
-    common/tr_inet_util.c
+    $(common_srcs) \
+    tid/example/tidc_main.c
 tid_example_tidc_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tidc_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tids_SOURCES = \
-    tid/example/tids_main.c \
-    common/tr_inet_util.c \
-    common/tr_socket.c
+    $(common_srcs) \
+    tid/example/tids_main.c
 tid_example_tids_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tids_LDFLAGS = $(AM_LDFLAGS) -pthread
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,29 +32,38 @@ common_srcs = common/tr_name.c \
 	common/tr_list.c \
 	$(mon_srcs)
 
-tid_srcs = tid/tid_resp.c \
-tid/tid_req.c \
-tid/tids.c \
-tid/tidc.c \
-common/tr_rand_id.c
+## TR gss sources
+gss_srcs = \
+    common/tr_gss.c \
+    common/tr_gss_client.c
 
-trp_srcs = trp/trp_conn.c \
-trp/trps.c \
-trp/trpc.c \
-trp/trp_peer.c \
-trp/trp_peer_encoders.c \
-trp/trp_ptable.c \
-trp/trp_ptable_encoders.c \
-trp/trp_route.c \
-trp/trp_route_encoders.c \
-trp/trp_rtable.c \
-trp/trp_rtable_encoders.c \
-trp/trp_req.c \
-trp/trp_upd.c \
-common/tr_mq.c \
-$(config_srcs)
+## TID processing sources - must also include gss_srcs
+tid_srcs = \
+    tid/tid_resp.c \
+    tid/tid_req.c \
+    tid/tids.c \
+    tid/tidc.c \
+    common/tr_rand_id.c
 
-# configuration parsing sources
+## TRP processing sources
+trp_srcs = \
+    trp/trp_conn.c \
+    trp/trps.c \
+    trp/trpc.c \
+    trp/trp_peer.c \
+    trp/trp_peer_encoders.c \
+    trp/trp_ptable.c \
+    trp/trp_ptable_encoders.c \
+    trp/trp_route.c \
+    trp/trp_route_encoders.c \
+    trp/trp_rtable.c \
+    trp/trp_rtable_encoders.c \
+    trp/trp_req.c \
+    trp/trp_upd.c \
+    common/tr_mq.c \
+    $(config_srcs)
+
+## configuration parsing sources
 config_srcs = \
     common/tr_config.c \
     common/tr_config_comms.c \
@@ -65,7 +74,7 @@ config_srcs = \
     common/tr_config_realms.c \
     common/tr_config_rp_clients.c
 
-# general monitoring message sources
+## general monitoring message sources
 mon_srcs =                   \
     mon/mon_common.c         \
     mon/mon_req.c            \
@@ -75,7 +84,7 @@ mon_srcs =                   \
     mon/mon_resp_decode.c    \
     mon/mon_resp_encode.c
 
-# monitoring server sources
+## monitoring server sources - must also include gss_srcs
 mons_srcs = \
     mon/mons.c \
     mon/mons_handlers.c
@@ -86,185 +95,196 @@ TEST_CFLAGS = -Wno-missing-prototypes
 
 lib_LTLIBRARIES = libtr_tid.la
 
-libtr_tid_la_SOURCES = $(tid_srcs) \
-$(common_srcs) \
-trp/trp_req.c \
-trp/trp_upd.c
+libtr_tid_la_SOURCES = \
+    $(common_srcs) \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    trp/trp_req.c \
+    trp/trp_upd.c
 
 libtr_tid_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 libtr_tid_la_LIBADD = gsscon/libgsscon.la $(GLIB_LIBS)
 libtr_tid_la_LDFLAGS = $(AM_LDFLAGS) -version-info 4:3:2 -no-undefined
 
-common_t_constraint_SOURCES = common/t_constraint.c \
-common/tr_debug.c \
-common/tr_name.c \
-common/tr_list.c \
-common/tr_constraint.c \
-common/tr_dh.c \
-common/tr_rand_id.c \
-tid/tid_req.c \
-tid/tid_resp.c
+common_t_constraint_SOURCES = \
+    common/t_constraint.c \
+    common/tr_debug.c \
+    common/tr_name.c \
+    common/tr_list.c \
+    common/tr_constraint.c \
+    common/tr_dh.c \
+    common/tr_rand_id.c \
+    tid/tid_req.c \
+    tid/tid_resp.c
 
 common_t_constraint_CPPFLAGS = $(AM_CPPFLAGS) -DTESTS=\"$(srcdir)/common/tests.json\"
 common_t_constraint_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 
-tr_trust_router_SOURCES =tr/tr_main.c \
-tr/tr.c \
-tr/tr_event.c \
-tr/tr_cfgwatch.c \
-tr/tr_tid.c \
-tr/tr_tid_mons.c \
-tr/tr_trp.c \
-tr/tr_trp_mons.c \
-tr/tr_mon.c \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(tid_srcs) \
-$(trp_srcs) \
-$(common_srcs) \
-$(mons_srcs)
+tr_trust_router_SOURCES = \
+    tr/tr_main.c \
+    tr/tr.c \
+    tr/tr_event.c \
+    tr/tr_cfgwatch.c \
+    tr/tr_tid.c \
+    tr/tr_tid_mons.c \
+    tr/tr_trp.c \
+    tr/tr_trp_mons.c \
+    tr/tr_mon.c \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs) \
+    $(common_srcs) \
+    $(mons_srcs)
 
 tr_trust_router_LDFLAGS = $(AM_LDFLAGS) -levent_pthreads -pthread
 tr_trust_router_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 
-tr_trpc_SOURCES =tr/trpc_main.c \
-tr/tr_trp.c \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(trp_srcs) \
-$(tid_srcs) \
-$(common_srcs)
+tr_trpc_SOURCES = \
+    tr/trpc_main.c \
+    tr/tr_trp.c \
+    $(trp_srcs) \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(common_srcs)
 
 tr_trpc_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 tr_trpc_LDFLAGS = $(AM_LDFLAGS) -pthread
 
-tr_trmon_SOURCES = tr/trmon_main.c \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(tid_srcs) \
-$(trp_srcs) \
-$(common_srcs) \
-mon/monc.c
+tr_trmon_SOURCES = \
+    tr/trmon_main.c \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs) \
+    $(common_srcs) \
+    mon/monc.c
 
 tr_trmon_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS)
 tr_trmon_LDFLAGS = $(AM_LDFLAGS) -pthread
 
-trp_msgtst_SOURCES = trp/msgtst.c \
-$(common_srcs) \
-common/tr_rand_id.c \
-trp/trp_req.c \
-trp/trp_upd.c \
-tid/tid_resp.c \
-tid/tid_req.c
+trp_msgtst_SOURCES = \
+    trp/msgtst.c \
+    $(common_srcs) \
+    common/tr_rand_id.c \
+    trp/trp_req.c \
+    trp/trp_upd.c \
+    tid/tid_resp.c \
+    tid/tid_req.c
 trp_msgtst_LDADD =  $(GLIB_LIBS)
 
-trp_test_rtbl_test_SOURCES = trp/test/rtbl_test.c \
-common/tr_name.c \
-common/tr_gss_names.c \
-common/tr_debug.c \
-common/tr_util.c \
-common/tr_inet_util.c \
-common/tr_list.c \
-trp/trp_route.c \
-trp/trp_route_encoders.c \
-trp/trp_rtable.c \
-trp/trp_rtable_encoders.c
+trp_test_rtbl_test_SOURCES = \
+    trp/test/rtbl_test.c \
+    common/tr_name.c \
+    common/tr_gss_names.c \
+    common/tr_debug.c \
+    common/tr_util.c \
+    common/tr_inet_util.c \
+    common/tr_list.c \
+    trp/trp_route.c \
+    trp/trp_route_encoders.c \
+    trp/trp_rtable.c \
+    trp/trp_rtable_encoders.c
 trp_test_rtbl_test_LDADD =  $(GLIB_LIBS)
 
-trp_test_ptbl_test_SOURCES = trp/test/ptbl_test.c \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(tid_srcs) \
-$(trp_srcs) \
-$(common_srcs)
+trp_test_ptbl_test_SOURCES = \
+    trp/test/ptbl_test.c \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs) \
+    $(common_srcs)
 trp_test_ptbl_test_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 trp_test_ptbl_test_LDFLAGS = $(AM_LDFLAGS) -pthread
 
-tid_example_tidc_SOURCES = tid/example/tidc_main.c \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(tid_srcs) \
-$(trp_srcs) \
-$(common_srcs)
+tid_example_tidc_SOURCES = \
+    tid/example/tidc_main.c \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs) \
+    $(common_srcs)
 tid_example_tidc_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS)
 tid_example_tidc_LDFLAGS = $(AM_LDFLAGS) -pthread
 
-tid_example_tids_SOURCES = tid/example/tids_main.c \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(tid_srcs) \
-$(trp_srcs) \
-$(common_srcs)
+tid_example_tids_SOURCES = \
+    tid/example/tids_main.c \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs) \
+    $(common_srcs)
 tid_example_tids_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS)
 tid_example_tids_LDFLAGS = $(AM_LDFLAGS) -pthread
 
-common_tests_tr_dh_test_SOURCES = common/tr_dh.c \
-common/tr_debug.c \
-common/tests/dh_test.c
+common_tests_tr_dh_test_SOURCES = \
+    common/tr_dh.c \
+    common/tr_debug.c \
+    common/tests/dh_test.c
 
-common_tests_mq_test_SOURCES = common/tr_mq.c \
-common/tests/mq_test.c \
-common/tr_debug.c
+common_tests_mq_test_SOURCES = \
+    common/tr_mq.c \
+    common/tests/mq_test.c \
+    common/tr_debug.c
 
 common_tests_mq_test_LDFLAGS = $(AM_LDFLAGS) -ltalloc -pthread
 
-common_tests_cfg_test_SOURCES = common/tests/cfg_test.c \
-$(common_srcs) \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(tid_srcs) \
-$(trp_srcs)
+common_tests_cfg_test_SOURCES = \
+    common/tests/cfg_test.c \
+    $(common_srcs) \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs)
 common_tests_cfg_test_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS)
 common_tests_cfg_test_LDFLAGS = $(AM_LDFLAGS) -ltalloc -pthread
 
-common_tests_thread_test_SOURCES = common/tr_mq.c \
-common/tr_debug.c \
-common/tests/thread_test.c
+common_tests_thread_test_SOURCES = \
+    common/tr_mq.c \
+    common/tr_debug.c \
+    common/tests/thread_test.c
 
-common_tests_commtest_SOURCES = common/tests/commtest.c \
-$(common_srcs) \
-common/tr_gss.c \
-common/tr_gss_client.c \
-$(tid_srcs) \
-$(trp_srcs)
+common_tests_commtest_SOURCES = \
+    common/tests/commtest.c \
+    $(common_srcs) \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs)
 common_tests_commtest_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 common_tests_commtest_LDFLAGS = $(AM_LDFLAGS) -ltalloc -pthread
 
 common_tests_thread_test_LDFLAGS = $(AM_LDFLAGS) -ltalloc -pthread
 
-common_tests_name_test_SOURCES = common/tests/name_test.c \
-              $(common_srcs) \
-              common/tr_gss.c \
-              common/tr_gss_client.c \
-              $(tid_srcs) \
-              $(trp_srcs)
+common_tests_name_test_SOURCES = \
+    common/tests/name_test.c \
+    $(common_srcs) \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs)
 common_tests_name_test_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 common_tests_name_test_LDFLAGS = $(AM_LDFLAGS) -ltalloc -pthread
 common_tests_name_test_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 
-common_tests_filt_test_SOURCES = common/tests/filt_test.c \
-              $(common_srcs) \
-              common/tr_gss.c \
-              common/tr_gss_client.c \
-              $(tid_srcs) \
-              $(trp_srcs)
+common_tests_filt_test_SOURCES = \
+    common/tests/filt_test.c \
+    $(common_srcs) \
+    $(gss_srcs) \
+    $(tid_srcs) \
+    $(trp_srcs)
 common_tests_filt_test_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
 common_tests_filt_test_LDFLAGS = $(AM_LDFLAGS) -ltalloc -pthread
 common_tests_filt_test_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 
-mon_tests_test_mon_req_encode_SOURCES = mon/tests/test_mon_req_encode.c \
+mon_tests_test_mon_req_encode_SOURCES = \
+    mon/tests/test_mon_req_encode.c \
     $(mon_srcs) \
     common/tr_name.c
 mon_tests_test_mon_req_encode_LDADD = $(GLIB_LIBS)
 mon_tests_test_mon_req_encode_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 
-mon_tests_test_mon_req_decode_SOURCES = mon/tests/test_mon_req_decode.c \
+mon_tests_test_mon_req_decode_SOURCES = \
+    mon/tests/test_mon_req_decode.c \
     $(mon_srcs) \
     common/tr_name.c
 mon_tests_test_mon_req_decode_LDADD = $(GLIB_LIBS)
 mon_tests_test_mon_req_decode_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 
-mon_tests_test_mon_resp_encode_SOURCES = mon/tests/test_mon_resp_encode.c \
+mon_tests_test_mon_resp_encode_SOURCES = \
+    mon/tests/test_mon_resp_encode.c \
     $(mon_srcs) \
     common/tr_name.c
 mon_tests_test_mon_resp_encode_LDADD = $(GLIB_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS= tr/trust_router tr/trpc tid/example/tidc tid/example/tids common/t
               mon/tests/test_mon_req_decode mon/tests/test_mon_resp_encode tr/trmon
 AM_CPPFLAGS=-I$(srcdir)/include $(GLIB_CFLAGS)
 AM_CFLAGS = -Wall -Werror=missing-prototypes -Werror -Wno-parentheses $(GLIB_CFLAGS)
-SUBDIRS = gsscon 
+SUBDIRS = gsscon
 common_srcs = common/tr_name.c \
 	common/tr_constraint.c \
 	common/jansson_iterators.h \
@@ -89,8 +89,13 @@ mons_srcs = \
     mon/mons.c \
     mon/mons_handlers.c
 
-check_PROGRAMS = common/t_constraint
-TESTS = common/t_constraint
+## Called by make check
+check_PROGRAMS = \
+    common/t_constraint \
+    tests/t_libtr_tid_la
+TESTS = \
+    common/t_constraint \
+    tests/t_libtr_tid_la
 TEST_CFLAGS = -Wno-missing-prototypes
 
 lib_LTLIBRARIES = libtr_tid.la
@@ -119,6 +124,9 @@ common_t_constraint_SOURCES = \
 
 common_t_constraint_CPPFLAGS = $(AM_CPPFLAGS) -DTESTS=\"$(srcdir)/common/tests.json\"
 common_t_constraint_LDADD = gsscon/libgsscon.la $(GLIB_LIBS)
+
+tests_t_libtr_tid_la_SOURCES = tests/t_libtr_tid_la.c
+tests_t_libtr_tid_la_LDADD = $(lib_LTLIBRARIES)
 
 tr_trust_router_SOURCES = \
     tr/tr_main.c \
@@ -196,20 +204,15 @@ trp_test_ptbl_test_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tidc_SOURCES = \
     tid/example/tidc_main.c \
-    $(gss_srcs) \
-    $(tid_srcs) \
-    $(trp_srcs) \
-    $(common_srcs)
-tid_example_tidc_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS)
+    common/tr_inet_util.c
+tid_example_tidc_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tidc_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tids_SOURCES = \
     tid/example/tids_main.c \
-    $(gss_srcs) \
-    $(tid_srcs) \
-    $(trp_srcs) \
-    $(common_srcs)
-tid_example_tids_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS)
+    common/tr_inet_util.c \
+    common/tr_socket.c
+tid_example_tids_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tids_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 common_tests_tr_dh_test_SOURCES = \
@@ -294,7 +297,7 @@ pkginclude_HEADERS = include/trust_router/tid.h include/trust_router/tr_name.h \
 	include/tr_debug.h include/trust_router/trp.h \
 	include/trust_router/tr_dh.h \
 	include/trust_router/tr_constraint.h \
-	include/trust_router/tr_versioning.h 
+	include/trust_router/tr_versioning.h
 
 noinst_HEADERS = include/gsscon.h \
     include/tr_config.h include/tr_cfgwatch.h \

--- a/tests/t_libtr_tid_la.c
+++ b/tests/t_libtr_tid_la.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018, JANET(UK)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JANET(UK) nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <assert.h>
+#include <trust_router/tid.h>
+
+/**
+ * Test that we can instantiate a TIDC instance
+ *
+ * The real purpose of this test is to ensure that the tidc_create()
+ * function is present in the libtr_tid shared library. This is the
+ * test that, e.g., FreeRADIUS uses to check that this library is present.
+ */
+static int tidc_create_exists(void)
+{
+  TIDC_INSTANCE *tidc = tidc_create();
+  if (!tidc)
+    return 0;
+  tidc_destroy(tidc);
+  return 1;
+}
+
+ /* Test linking against libtr_tid */
+ int main(void)
+ {
+   assert(tidc_create_exists());
+   return 0;
+ }

--- a/tr/internal.cfg
+++ b/tr/internal.cfg
@@ -14,6 +14,13 @@
     "logging": {
       "log_threshold": "info",
       "console_threshold":"notice"
+    },
+    "monitoring": {
+      "enabled": true,
+      "port": 12310,
+      "authorized_credentials": [
+        "monitor@apc.x"
+      ]
     }
   }
 }


### PR DESCRIPTION
This pull request resolves #102 by including `tr_gss.c` and `tr_gss_client.c` in the `libtr_tid.la` library sources. Without this, the library built but could not be linked against due to missing symbols.

To prevent accidental release of an unlinkable library in the future, this pull request also:
  * cleans up `Makefile.am` to make errors like this one less likely
  * builds a test program (`tests/t_libtr_tid_la`) against the library as part of `make check`
  * uses the `libtr_tid.la` library for `trust_router`, `tidc`, and `tids` binaries instead of duplicating the TID code

This also fixes #103, a bug that was discovered while testing the above.