### PR TITLE
Disentangle source dependencies so libtr_tid does not need TRP and MON support to build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,7 +114,7 @@ libtr_tid_la_SOURCES = \
 
 libtr_tid_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 libtr_tid_la_LIBADD = gsscon/libgsscon.la $(GLIB_LIBS)
-libtr_tid_la_LDFLAGS = $(AM_LDFLAGS) -version-info 4:3:2 -no-undefined
+libtr_tid_la_LDFLAGS = $(AM_LDFLAGS) -version-info 5:0:3 -no-undefined
 
 common_t_constraint_SOURCES = \
     common/t_constraint.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -345,6 +345,23 @@ if HAVE_SYSTEMD
 systemdsystemunit_DATA = tids.service
 endif
 
-EXTRA_DIST = trust_router.spec common/tests.json schema.sql tids.service \
+EXTRA_DIST = \
+	CMakeLists.txt \
+	m4/.ignore-this-file \
+	trust_router.spec \
+	common/tests.json \
+	common/tests/idp.cfg \
+	common/tests/test-filters/filt-inforec-1-msg.json \
+	common/tests/test-filters/filt-inforec-1.json \
+	common/tests/test-filters/filt-tidreq-1-msg.json \
+	common/tests/test-filters/filt-tidreq-1.json \
+	common/tests/test-filters/filter-tests.json \
+	common/tests/test-filters/invalid-filt-repeated-key.json \
+	common/tests/test-filters/invalid-filt-unknown-field.json \
+	common/tests/test-filters/valid-filt.json \
+	mon/tests/req_show_all_options.test \
+	mon/tests/req_show_no_options.test \
+	mon/tests/resp_show_success.test \
+	schema.sql tids.service \
 	tr/internal.cfg tr/organizations.cfg \
 	redhat/tids.init

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,29 +8,30 @@ bin_PROGRAMS= tr/trust_router tr/trpc tid/example/tidc tid/example/tids common/t
 AM_CPPFLAGS=-I$(srcdir)/include $(GLIB_CFLAGS)
 AM_CFLAGS = -Wall -Werror=missing-prototypes -Werror -Wno-parentheses $(GLIB_CFLAGS)
 SUBDIRS = gsscon
-common_srcs = common/tr_name.c \
-	common/tr_constraint.c \
-	common/jansson_iterators.h \
-	common/tr_msg.c \
-	common/tr_dh.c \
+common_srcs = \
+    common/tr_name.c \
+    common/jansson_iterators.h \
+    common/tr_dh.c \
     common/tr_debug.c \
-	common/tr_util.c \
-	common/tr_inet_util.c \
-	common/tr_apc.c \
-	common/tr_comm.c \
-	common/tr_comm_encoders.c \
-	common/tr_rp.c \
-	common/tr_rp_client.c \
-	common/tr_rp_client_encoders.c \
-	common/tr_idp.c \
-	common/tr_aaa_server.c \
-	common/tr_idp_encoders.c \
-	common/tr_filter.c \
-	common/tr_filter_encoders.c \
-	common/tr_gss_names.c \
-	common/tr_socket.c \
-	common/tr_list.c \
-	$(mon_srcs)
+    common/tr_util.c \
+    common/tr_inet_util.c \
+    common/tr_apc.c \
+    common/tr_comm.c \
+    common/tr_comm_encoders.c \
+    common/tr_rp.c \
+    common/tr_idp.c \
+    common/tr_aaa_server.c \
+    common/tr_idp_encoders.c \
+    common/tr_gss_names.c \
+    common/tr_socket.c \
+    common/tr_list.c \
+    common/tr_msg.c \
+    common/tr_constraint.c \
+    common/tr_filter.c \
+    common/tr_filter_encoders.c \
+    common/tr_rp_client.c \
+    common/tr_rp_client_encoders.c \
+    $(mon_srcs)
 
 ## TR gss sources
 gss_srcs = \
@@ -43,6 +44,7 @@ tid_srcs = \
     tid/tid_req.c \
     tid/tids.c \
     tid/tidc.c \
+    tid/tid_tr_msg.c \
     common/tr_rand_id.c
 
 ## TRP processing sources
@@ -60,6 +62,8 @@ trp_srcs = \
     trp/trp_rtable_encoders.c \
     trp/trp_req.c \
     trp/trp_upd.c \
+    trp/trp_tr_msg.c \
+    trp/trp_filter.c \
     common/tr_mq.c \
     $(config_srcs)
 
@@ -82,7 +86,8 @@ mon_srcs =                   \
     mon/mon_req_decode.c     \
     mon/mon_resp.c           \
     mon/mon_resp_decode.c    \
-    mon/mon_resp_encode.c
+    mon/mon_resp_encode.c    \
+    mon/mon_tr_msg.c
 
 ## monitoring server sources - must also include gss_srcs
 mons_srcs = \
@@ -139,9 +144,14 @@ tr_trust_router_SOURCES = \
     tr/tr_trp.c \
     tr/tr_trp_mons.c \
     tr/tr_mon.c \
+    $(tid_srcs) \
     $(trp_srcs) \
     $(gss_srcs) \
     $(mons_srcs)
+
+## These last three should not be here, but are required until we untangle dependencies
+## between tr_msg.c, tr_constraint.c, and the tid internal code. We ought to be able to
+## implement a trust router using only the public interface of libtr_tid
 
 tr_trust_router_LDFLAGS = $(AM_LDFLAGS) -levent_pthreads -pthread
 tr_trust_router_LDADD = gsscon/libgsscon.la $(GLIB_LIBS) $(lib_LTLIBRARIES)
@@ -203,12 +213,16 @@ trp_test_ptbl_test_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tidc_SOURCES = \
     $(common_srcs) \
+    $(tid_srcs) \
+    $(gss_srcs) \
     tid/example/tidc_main.c
 tid_example_tidc_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tidc_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tids_SOURCES = \
     $(common_srcs) \
+    $(tid_srcs) \
+    $(gss_srcs) \
     tid/example/tids_main.c
 tid_example_tids_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tids_LDFLAGS = $(AM_LDFLAGS) -pthread
@@ -273,6 +287,8 @@ common_tests_filt_test_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 mon_tests_test_mon_req_encode_SOURCES = \
     mon/tests/test_mon_req_encode.c \
     $(mon_srcs) \
+    common/tr_msg.c \
+    common/tr_debug.c \
     common/tr_name.c
 mon_tests_test_mon_req_encode_LDADD = $(GLIB_LIBS)
 mon_tests_test_mon_req_encode_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
@@ -280,6 +296,8 @@ mon_tests_test_mon_req_encode_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 mon_tests_test_mon_req_decode_SOURCES = \
     mon/tests/test_mon_req_decode.c \
     $(mon_srcs) \
+    common/tr_msg.c \
+    common/tr_debug.c \
     common/tr_name.c
 mon_tests_test_mon_req_decode_LDADD = $(GLIB_LIBS)
 mon_tests_test_mon_req_decode_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
@@ -287,6 +305,8 @@ mon_tests_test_mon_req_decode_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 mon_tests_test_mon_resp_encode_SOURCES = \
     mon/tests/test_mon_resp_encode.c \
     $(mon_srcs) \
+    common/tr_msg.c \
+    common/tr_debug.c \
     common/tr_name.c
 mon_tests_test_mon_resp_encode_LDADD = $(GLIB_LIBS)
 mon_tests_test_mon_resp_encode_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,6 @@ common_srcs = \
     common/tr_socket.c \
     common/tr_list.c \
     common/tr_msg.c \
-    common/tr_constraint.c \
     common/tr_filter.c \
     common/tr_filter_encoders.c \
     common/tr_rp_client.c \
@@ -45,6 +44,7 @@ tid_srcs = \
     tid/tids.c \
     tid/tidc.c \
     tid/tid_tr_msg.c \
+    common/tr_constraint.c \
     common/tr_rand_id.c
 
 ## TRP processing sources
@@ -144,7 +144,6 @@ tr_trust_router_SOURCES = \
     tr/tr_trp.c \
     tr/tr_trp_mons.c \
     tr/tr_mon.c \
-    $(tid_srcs) \
     $(trp_srcs) \
     $(gss_srcs) \
     $(mons_srcs)
@@ -181,6 +180,7 @@ tr_trmon_LDFLAGS = $(AM_LDFLAGS) -pthread
 trp_msgtst_SOURCES = \
     trp/msgtst.c \
     $(common_srcs) \
+    common/tr_constraint.c \
     common/tr_rand_id.c \
     trp/trp_req.c \
     trp/trp_upd.c \
@@ -213,16 +213,12 @@ trp_test_ptbl_test_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tidc_SOURCES = \
     $(common_srcs) \
-    $(tid_srcs) \
-    $(gss_srcs) \
     tid/example/tidc_main.c
 tid_example_tidc_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tidc_LDFLAGS = $(AM_LDFLAGS) -pthread
 
 tid_example_tids_SOURCES = \
     $(common_srcs) \
-    $(tid_srcs) \
-    $(gss_srcs) \
     tid/example/tids_main.c
 tid_example_tids_LDADD = gsscon/libgsscon.la  $(GLIB_LIBS) $(lib_LTLIBRARIES)
 tid_example_tids_LDFLAGS = $(AM_LDFLAGS) -pthread

--- a/common/tests/filt_test.c
+++ b/common/tests/filt_test.c
@@ -120,7 +120,7 @@ TRP_INFOREC *load_inforec(const char *fname)
 
   assert(encoded);
   assert(msg= tr_msg_decode(NULL, encoded, strlen(encoded)));
-  assert(upd=tr_msg_get_trp_upd(msg));
+  assert(upd= trp_get_tr_msg_upd(msg));
   assert(inforec=trp_upd_get_inforec(upd));
   /* now remove the inforec from the update context */
   talloc_steal(NULL, inforec);
@@ -151,11 +151,11 @@ TID_REQ *load_tid_req(const char *fname)
   msgbuf=NULL;
 
   assert(msg);
-  assert(NULL != tr_msg_get_req(msg)); /* checks that this is a TID request */
+  assert(NULL != tid_get_tr_msg_req(msg)); /* checks that this is a TID request */
 
   /* take the tid req out of the msg */
-  out=tr_msg_get_req(msg);
-  tr_msg_set_req(msg, NULL);
+  out= tid_get_tr_msg_req(msg);
+  tid_set_tr_msg_req(msg, NULL);
   assert(out);
 
   tr_msg_free_decoded(msg);
@@ -197,7 +197,7 @@ int test_one_filter(char *filt_fname,
     case TR_FILTER_TYPE_TRP_INBOUND:
     case TR_FILTER_TYPE_TRP_OUTBOUND:
       /* TODO: read realm and community */
-      target= tr_filter_target_trp_inforec(NULL, NULL, load_inforec(target_fname));
+      target= trp_filter_target_inforec(NULL, NULL, load_inforec(target_fname));
       break;
 
     default:
@@ -269,8 +269,8 @@ int test_filter(void)
 
 int main(void)
 {
-  tr_msg_tid_init();
-  tr_msg_trp_init();
+  tid_tr_msg_init();
+  trp_tr_msg_init();
   trp_filter_init();
 
   assert(test_load_filter());

--- a/common/tests/filt_test.c
+++ b/common/tests/filt_test.c
@@ -151,7 +151,7 @@ TID_REQ *load_tid_req(const char *fname)
   msgbuf=NULL;
 
   assert(msg);
-  assert(tr_msg_get_msg_type(msg)==TID_REQUEST);
+  assert(NULL != tr_msg_get_req(msg)); /* checks that this is a TID request */
 
   /* take the tid req out of the msg */
   out=tr_msg_get_req(msg);
@@ -269,6 +269,10 @@ int test_filter(void)
 
 int main(void)
 {
+  tr_msg_tid_init();
+  tr_msg_trp_init();
+  trp_filter_init();
+
   assert(test_load_filter());
   assert(test_filter());
   printf("Success\n");

--- a/common/tr_constraint.c
+++ b/common/tr_constraint.c
@@ -153,7 +153,7 @@ cleanup:
  * Allows for a single '*' as the wildcard character if it is the first character. Leading white
  * space is significant.
  */
-static int tr_prefix_wildcard_match(const char *str, const char *wc_str)
+int tr_prefix_wildcard_match(const char *str, const char *wc_str)
 {
   const char *wc_post = wc_str;
   size_t len = 0;

--- a/common/tr_constraint.c
+++ b/common/tr_constraint.c
@@ -153,7 +153,7 @@ cleanup:
  * Allows for a single '*' as the wildcard character if it is the first character. Leading white
  * space is significant.
  */
-int tr_prefix_wildcard_match(const char *str, const char *wc_str)
+static int tr_prefix_wildcard_match(const char *str, const char *wc_str)
 {
   const char *wc_post = wc_str;
   size_t len = 0;

--- a/common/tr_filter.c
+++ b/common/tr_filter.c
@@ -32,28 +32,19 @@
  *
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <talloc.h>
-#include <assert.h>
 
 #include <tr_filter.h>
-#include <trp_internal.h>
 #include <tid_internal.h>
-#include <tr_inet_util.h>
 #include <tr_debug.h>
 
 /* Function types for handling filter fields generally. All target values
  * are represented as strings in a TR_NAME.
  */
 
-/* CMP functions return values like strcmp: 0 on match, <0 on target<val, >0 on target>val */
-typedef int (*TR_FILTER_FIELD_CMP)(TR_FILTER_TARGET *target, TR_NAME *val);
-/* get functions return TR_NAME format of the field value. Caller must free it. */
-typedef TR_NAME *(*TR_FILTER_FIELD_GET)(TR_FILTER_TARGET *target);
-
-static TR_FILTER_TARGET *tr_filter_target_new(TALLOC_CTX *mem_ctx)
+TR_FILTER_TARGET *tr_filter_target_new(TALLOC_CTX *mem_ctx)
 {
   TR_FILTER_TARGET *target=talloc(mem_ctx, TR_FILTER_TARGET);
   if (target) {
@@ -84,25 +75,6 @@ TR_FILTER_TARGET *tr_filter_target_tid_req(TALLOC_CTX *mem_ctx, TID_REQ *req)
   return target;
 }
 
-/**
- * Create a filter target for a TRP inforec. Does not change the context of the inforec or duplicate TR_NAMEs,
- * so this is only valid until those are freed.
- *
- * @param mem_ctx talloc context for the object
- * @param upd Update containing the TRP inforec
- * @param inforec TRP inforec
- * @return pointer to a TR_FILTER_TARGET structure, or null on allocation failure
- */
-TR_FILTER_TARGET *tr_filter_target_trp_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd, TRP_INFOREC *inforec)
-{
-  TR_FILTER_TARGET *target=tr_filter_target_new(mem_ctx);
-  if (target) {
-    target->trp_inforec = inforec; /* borrowed, not adding to our context */
-    target->trp_upd=upd;
-  }
-  return target;
-}
-
 /** Handler functions for TID RP_REALM field */
 static int tr_ff_cmp_tid_rp_realm(TR_FILTER_TARGET *target, TR_NAME *val)
 {
@@ -112,45 +84,6 @@ static int tr_ff_cmp_tid_rp_realm(TR_FILTER_TARGET *target, TR_NAME *val)
 static TR_NAME *tr_ff_get_tid_rp_realm(TR_FILTER_TARGET *target)
 {
   return tr_dup_name(tid_req_get_rp_realm(target->tid_req));
-}
-
-/** Handler functions for TRP info_type field */
-static int tr_ff_cmp_trp_info_type(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  TRP_INFOREC *inforec=target->trp_inforec;
-  char *valstr=NULL;
-  int val_type=0;
-
-  assert(val);
-  assert(inforec);
-
-  /* nothing matches unknown */
-  if (inforec->type==TRP_INFOREC_TYPE_UNKNOWN)
-    return 0;
-
-  valstr = tr_name_strdup(val); /* get this as an official null-terminated string */
-  val_type = trp_inforec_type_from_string(valstr);
-  free(valstr);
-
-  /* we do not define an ordering of info types */
-  return (val_type==inforec->type);
-}
-
-static TR_NAME *tr_ff_get_trp_info_type(TR_FILTER_TARGET *target)
-{
-  TRP_INFOREC *inforec=target->trp_inforec;
-  return tr_new_name(trp_inforec_type_to_string(inforec->type));
-}
-
-/** Handlers for TRP realm field */
-static int tr_ff_cmp_trp_realm(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  return tr_name_cmp(trp_upd_get_realm(target->trp_upd), val);
-}
-
-static TR_NAME *tr_ff_get_trp_realm(TR_FILTER_TARGET *target)
-{
-  return tr_dup_name(trp_upd_get_realm(target->trp_upd));
 }
 
 /** Handlers for TID realm field */
@@ -164,17 +97,6 @@ static TR_NAME *tr_ff_get_tid_realm(TR_FILTER_TARGET *target)
   return tr_dup_name(tid_req_get_realm(target->tid_req));
 }
 
-/** Handlers for TRP community field */
-static int tr_ff_cmp_trp_comm(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  return tr_name_cmp(trp_upd_get_comm(target->trp_upd), val);
-}
-
-static TR_NAME *tr_ff_get_trp_comm(TR_FILTER_TARGET *target)
-{
-  return tr_dup_name(trp_upd_get_comm(target->trp_upd));
-}
-
 /** Handlers for TID community field */
 static int tr_ff_cmp_tid_comm(TR_FILTER_TARGET *target, TR_NAME *val)
 {
@@ -184,167 +106,6 @@ static int tr_ff_cmp_tid_comm(TR_FILTER_TARGET *target, TR_NAME *val)
 static TR_NAME *tr_ff_get_tid_comm(TR_FILTER_TARGET *target)
 {
   return tr_dup_name(tid_req_get_comm(target->tid_req));
-}
-
-/** Handlers for TRP community_type field */
-static TR_NAME *tr_ff_get_trp_comm_type(TR_FILTER_TARGET *target)
-{
-  TR_NAME *type=NULL;
-
-  switch(trp_inforec_get_comm_type(target->trp_inforec)) {
-    case TR_COMM_APC:
-      type=tr_new_name("apc");
-      break;
-    case TR_COMM_COI:
-      type=tr_new_name("coi");
-      break;
-    default:
-      type=NULL;
-      break; /* unknown types always fail */
-  }
-
-  return type;
-}
-
-static int tr_ff_cmp_trp_comm_type(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  TR_NAME *type=tr_ff_get_trp_comm_type(target);
-  int retval=0;
-
-  if (type==NULL)
-    retval=1;
-  else {
-    retval = tr_name_cmp(val, type);
-    tr_free_name(type);
-  }
-  return retval;
-}
-
-/** Handlers for TRP realm_role field */
-static TR_NAME *tr_ff_get_trp_realm_role(TR_FILTER_TARGET *target)
-{
-  TR_NAME *type=NULL;
-
-  switch(trp_inforec_get_role(target->trp_inforec)) {
-    case TR_ROLE_IDP:
-      type=tr_new_name("idp");
-      break;
-    case TR_ROLE_RP:
-      type=tr_new_name("rp");
-      break;
-    default:
-      type=NULL;
-      break; /* unknown types always fail */
-  }
-
-  return type;
-}
-
-static int tr_ff_cmp_trp_realm_role(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  TR_NAME *type=tr_ff_get_trp_realm_role(target);
-  int retval=0;
-
-  if (type==NULL)
-    retval=1;
-  else {
-    retval = tr_name_cmp(val, type);
-    tr_free_name(type);
-  }
-  return retval;
-}
-
-/** Handlers for TRP apc field */
-/* TODO: Handle multiple APCs, not just the first */
-static int tr_ff_cmp_trp_apc(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  return tr_name_cmp(tr_apc_get_id(trp_inforec_get_apcs(target->trp_inforec)), val);
-}
-
-static TR_NAME *tr_ff_get_trp_apc(TR_FILTER_TARGET *target)
-{
-  TR_APC *apc=trp_inforec_get_apcs(target->trp_inforec);
-  if (apc==NULL)
-    return NULL;
-
-  return tr_dup_name(tr_apc_get_id(apc));
-}
-
-/** Handlers for TRP owner_realm field */
-static int tr_ff_cmp_trp_owner_realm(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  return tr_name_cmp(trp_inforec_get_owner_realm(target->trp_inforec), val);
-}
-
-static TR_NAME *tr_ff_get_trp_owner_realm(TR_FILTER_TARGET *target)
-{
-  return tr_dup_name(trp_inforec_get_owner_realm(target->trp_inforec));
-}
-
-/** Generic handlers for host:port fields*/
-static TR_NAME *tr_ff_get_hostname_and_port(TR_NAME *hn, int port)
-{
-  return tr_hostname_and_port_to_name(hn, port);
-}
-
-static int tr_ff_cmp_hostname_and_port(TR_NAME *hn, int port, int default_port, TR_NAME *val)
-{
-  int cmp = -1;
-  TR_NAME *n = NULL;
-
-  /* allow a match without :port if the default port is in use */
-  if ((port == default_port) && (tr_name_cmp(hn, val) == 0))
-    return 0;
-
-  /* need to match with the :port */
-  n = tr_ff_get_hostname_and_port(hn, port);
-
-  if (n) {
-    cmp = tr_name_cmp(n, val);
-    tr_free_name(n);
-  }
-  return cmp;
-}
-
-/** Handlers for TRP trust_router field */
-static int tr_ff_cmp_trp_trust_router(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  return tr_ff_cmp_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
-                                     trp_inforec_get_trust_router_port(target->trp_inforec),
-                                     TRP_PORT,
-                                     val);
-}
-
-static TR_NAME *tr_ff_get_trp_trust_router(TR_FILTER_TARGET *target)
-{
-  return tr_ff_get_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
-                                     trp_inforec_get_trust_router_port(target->trp_inforec));
-}
-
-/** Handlers for TRP next_hop field */
-static int tr_ff_cmp_trp_next_hop(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  return tr_ff_cmp_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
-                                     trp_inforec_get_next_hop_port(target->trp_inforec),
-                                     TID_PORT,
-                                     val);
-}
-
-static TR_NAME *tr_ff_get_trp_next_hop(TR_FILTER_TARGET *target)
-{
-  return tr_ff_get_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
-                                     trp_inforec_get_next_hop_port(target->trp_inforec));
-}
-
-/** Handlers for TRP owner_contact field */
-static int tr_ff_cmp_trp_owner_contact(TR_FILTER_TARGET *target, TR_NAME *val)
-{
-  return tr_name_cmp(trp_inforec_get_owner_contact(target->trp_inforec), val);
-}
-
-static TR_NAME *tr_ff_get_trp_owner_contact(TR_FILTER_TARGET *target)
-{
-  return tr_dup_name(trp_inforec_get_owner_contact(target->trp_inforec));
 }
 
 /** Handlers for TID req original_coi field */
@@ -361,64 +122,67 @@ static TR_NAME *tr_ff_get_tid_orig_coi(TR_FILTER_TARGET *target)
 /**
  * Filter field handler table
  */
+#define FILTER_FIELD_NAME_LEN 50
 struct tr_filter_field_entry {
   TR_FILTER_TYPE filter_type;
-  const char *name;
-  TR_FILTER_FIELD_CMP cmp;
-  TR_FILTER_FIELD_GET get;
+  char name[FILTER_FIELD_NAME_LEN+1];
+  TR_FILTER_FIELD_CMP *cmp;
+  TR_FILTER_FIELD_GET *get;
 };
-static struct tr_filter_field_entry tr_filter_field_table[] = {
-    /* realm */
-    {TR_FILTER_TYPE_TID_INBOUND, "realm", tr_ff_cmp_tid_realm, tr_ff_get_tid_realm},
-    {TR_FILTER_TYPE_TRP_INBOUND, "realm", tr_ff_cmp_trp_realm, tr_ff_get_trp_realm},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "realm", tr_ff_cmp_trp_realm, tr_ff_get_trp_realm},
+/* As of now, we use 24 of these when the TRP module is present */
+#define FILTER_FIELD_TABLE_LEN 30
+static struct tr_filter_field_entry tr_filter_field_table[FILTER_FIELD_TABLE_LEN] = {
+  /* realm */
+  {TR_FILTER_TYPE_TID_INBOUND, "realm", tr_ff_cmp_tid_realm, tr_ff_get_tid_realm},
 
-    /* community */
-    {TR_FILTER_TYPE_TID_INBOUND, "comm", tr_ff_cmp_tid_comm, tr_ff_get_tid_comm},
-    {TR_FILTER_TYPE_TRP_INBOUND, "comm", tr_ff_cmp_trp_comm, tr_ff_get_trp_comm},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "comm", tr_ff_cmp_trp_comm, tr_ff_get_trp_comm},
+  /* community */
+  {TR_FILTER_TYPE_TID_INBOUND, "comm", tr_ff_cmp_tid_comm, tr_ff_get_tid_comm},
 
-    /* community type */
-    {TR_FILTER_TYPE_TRP_INBOUND, "comm_type", tr_ff_cmp_trp_comm_type, tr_ff_get_trp_comm_type},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "comm_type", tr_ff_cmp_trp_comm_type, tr_ff_get_trp_comm_type},
+  /* rp_realm */
+  {TR_FILTER_TYPE_TID_INBOUND, "rp_realm", tr_ff_cmp_tid_rp_realm, tr_ff_get_tid_rp_realm},
 
-    /* realm role */
-    {TR_FILTER_TYPE_TRP_INBOUND, "realm_role", tr_ff_cmp_trp_realm_role, tr_ff_get_trp_realm_role},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "realm_role", tr_ff_cmp_trp_realm_role, tr_ff_get_trp_realm_role},
+  /* original coi */
+  {TR_FILTER_TYPE_TID_INBOUND, "original_coi", tr_ff_cmp_tid_orig_coi, tr_ff_get_tid_orig_coi},
 
-    /* apc */
-    {TR_FILTER_TYPE_TRP_INBOUND, "apc", tr_ff_cmp_trp_apc, tr_ff_get_trp_apc},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "apc", tr_ff_cmp_trp_apc, tr_ff_get_trp_apc},
-
-    /* trust_router */
-    {TR_FILTER_TYPE_TRP_INBOUND, "trust_router", tr_ff_cmp_trp_trust_router, tr_ff_get_trp_trust_router},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "trust_router", tr_ff_cmp_trp_trust_router, tr_ff_get_trp_trust_router},
-
-    /* next_hop */
-    {TR_FILTER_TYPE_TRP_INBOUND, "next_hop", tr_ff_cmp_trp_next_hop, tr_ff_get_trp_next_hop},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "next_hop", tr_ff_cmp_trp_next_hop, tr_ff_get_trp_next_hop},
-
-    /* owner_realm */
-    {TR_FILTER_TYPE_TRP_INBOUND, "owner_realm", tr_ff_cmp_trp_owner_realm, tr_ff_get_trp_owner_realm},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "owner_realm", tr_ff_cmp_trp_owner_realm, tr_ff_get_trp_owner_realm},
-
-    /* owner_contact */
-    {TR_FILTER_TYPE_TRP_INBOUND, "owner_contact", tr_ff_cmp_trp_owner_contact, tr_ff_get_trp_owner_contact},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "owner_contact", tr_ff_cmp_trp_owner_contact, tr_ff_get_trp_owner_contact},
-
-    /* rp_realm */
-    {TR_FILTER_TYPE_TID_INBOUND, "rp_realm", tr_ff_cmp_tid_rp_realm, tr_ff_get_tid_rp_realm},
-
-    /* original coi */
-    {TR_FILTER_TYPE_TID_INBOUND, "original_coi", tr_ff_cmp_tid_orig_coi, tr_ff_get_tid_orig_coi},
-
-    /* info_type */
-    {TR_FILTER_TYPE_TRP_INBOUND, "info_type", tr_ff_cmp_trp_info_type, tr_ff_get_trp_info_type},
-    {TR_FILTER_TYPE_TRP_OUTBOUND, "info_type", tr_ff_cmp_trp_info_type, tr_ff_get_trp_info_type},
-
-    /* Unknown */
-    {TR_FILTER_TYPE_UNKNOWN, NULL } /* This must be the final entry */
+  /* The rest start off as 0 (TYPE_UNKNOWN) */
+  {0}
 };
+
+int tr_filter_add_field_handler(TR_FILTER_TYPE ftype,
+                                const char *name,
+                                TR_FILTER_FIELD_CMP *cmp,
+                                TR_FILTER_FIELD_GET *get)
+{
+  size_t ii;
+  struct tr_filter_field_entry *handler;
+
+  for (ii=0; ii < FILTER_FIELD_TABLE_LEN; ii++) {
+    handler = &(tr_filter_field_table[ii]);
+    if ((handler->filter_type == TR_FILTER_TYPE_UNKNOWN)
+       || ((handler->filter_type == ftype)
+          && (0 == strcmp(name, handler->name)))) {
+      /* Entry already exists */
+      break;
+    }
+  }
+
+  if (ii >= FILTER_FIELD_TABLE_LEN) {
+    tr_debug("tr_filter_add_field_handler: table full adding filter_type=%d, name=%s",
+             ftype,
+             name);
+    return 0;
+  }
+
+  /* Now fill in the table, replacing one if it already existed.
+   * If we're here, handler points at the correct entry in the table. */
+  handler->filter_type = ftype;
+  strncpy(handler->name, name, FILTER_FIELD_NAME_LEN);
+  handler->name[FILTER_FIELD_NAME_LEN] = '\0'; /* just to be sure */
+  handler->cmp = cmp;
+  handler->get = get;
+
+  return 1;
+}
 
 /* TODO: support TRP metric field (requires > < comparison instead of wildcard match) */
 
@@ -673,7 +437,7 @@ int tr_filter_validate(TR_FILTER *filt)
   TR_FLINE *this_fline = NULL;
   TR_FLINE_ITER *fline_iter = tr_fline_iter_new(tmp_ctx);
   TR_FSPEC *this_fspec = NULL;
-  
+
   if ((!filt) || (!filt_iter) || (!fline_iter)) {
     talloc_free(tmp_ctx);
     return 0;
@@ -690,7 +454,7 @@ int tr_filter_validate(TR_FILTER *filt)
       talloc_free(tmp_ctx);
       return 0; /* if we get here, either TR_FILTER_TYPE_UNKNOWN or an invalid value was found */
   }
-  
+
   for (this_fline = tr_filter_iter_first(filt_iter, filt);
        this_fline != NULL;
        this_fline = tr_filter_iter_next(filt_iter)) {
@@ -846,4 +610,3 @@ TR_FILTER_TYPE tr_filter_type_from_string(const char *s)
   }
   return TR_FILTER_TYPE_UNKNOWN;
 }
-

--- a/common/tr_filter.c
+++ b/common/tr_filter.c
@@ -40,10 +40,22 @@
 #include <tid_internal.h>
 #include <tr_debug.h>
 
-/* Function types for handling filter fields generally. All target values
- * are represented as strings in a TR_NAME.
+/**
+ * Notes on filter field handlers
+ *
+ * A dynamic table of fields is maintained. A protocol should register
+ * a compare function with signature TR_FILTER_FIELD_CMP and a getter
+ * function with signature TR_FILTER_FIELD_GET. These handlers are
+ * registered with tr_filter_add_field_handler().
+ *
+ * Field handlers for the TID protocol are initialized automatically.
+ * This could be broken out, but it is unclear that this module will
+ * ever be used in programs that do not need to handle TID messages.
+ *
+ * The filter types must be defined in the TR_FILTER_TYPE enum. This
+ * could be done dynamically (like in tr_msg.c), but it's unclear that
+ * this would be practically useful.
  */
-
 TR_FILTER_TARGET *tr_filter_target_new(TALLOC_CTX *mem_ctx)
 {
   TR_FILTER_TARGET *target=talloc(mem_ctx, TR_FILTER_TARGET);

--- a/common/tr_msg.c
+++ b/common/tr_msg.c
@@ -51,6 +51,22 @@
 #include <tr_debug.h>
 #include <tr_inet_util.h>
 
+/**
+ * Notes on message encoders/decoders
+ *
+ * A dynamic table of protocol-specific message types, encoders, and decoders
+ * is maintained.
+ *
+ * In order to send/receive messages, an encoder/decoder function must
+ * be added to the table using the tr_msg_register_type()
+ * function. This requires a label for the message type (which appears
+ * in the protocol message header) and at least encoder with signature
+ * TR_MESSAGE_ENCODE_FUNC and/or a decoder with signature
+ * TR_MESSAGE_DECODE_FUNC. At least one of these is required.
+ *
+ * This call returns an opaque TR_MSG_TYPE token which the caller
+ * should record to use when creating / retrieving messages.
+ */
 #define MAX_MSG_TYPES 10
 static TR_MSG_TYPE_HANDLER msg_type_handler_table[MAX_MSG_TYPES] = {{0}};
 

--- a/common/tr_msg.c
+++ b/common/tr_msg.c
@@ -43,8 +43,6 @@
 
 #include <tr_apc.h>
 #include <tr_comm.h>
-#include <trp_internal.h>
-#include <mon_internal.h>
 #include <tr_msg.h>
 #include <tr_util.h>
 #include <tr_name_internal.h>
@@ -53,1363 +51,118 @@
 #include <tr_debug.h>
 #include <tr_inet_util.h>
 
-/* JSON helpers */
-/* Read attribute attr from msg as an integer. */
-static TRP_RC tr_msg_get_json_integer(json_t *jmsg, const char *attr, int *dest)
+#define MAX_MSG_TYPES 10
+static TR_MSG_TYPE_HANDLER msg_type_handler_table[MAX_MSG_TYPES] = {{0}};
+
+static TR_MSG_TYPE_HANDLER *get_msg_type_handler(TR_MSG_TYPE msg_type)
 {
-  json_t *obj;
+  /* In this implementation, the (msg_type-1)th entry in the table will
+   * always be the handler for msg_type. Just check that it is not undefined */
+  if (msg_type_handler_table[msg_type - 1].msg_type == msg_type)
+    return &(msg_type_handler_table[msg_type - 1]);
 
-  obj=json_object_get(jmsg, attr);
-  if (obj == NULL) {
-    return TRP_MISSING;
-  }
-  /* check type */
-  if (!json_is_integer(obj)) {
-    return TRP_BADTYPE;
-  }
-
-  (*dest)=json_integer_value(obj);
-  return TRP_SUCCESS;
+  return NULL;
 }
 
-/* Read attribute attr from msg as a string. Copies string into mem_ctx context so jmsg can
- * be destroyed safely. Returns nonzero on error. */
-static TRP_RC tr_msg_get_json_string(json_t *jmsg, const char *attr, char **dest, TALLOC_CTX *mem_ctx)
+static TR_MSG_TYPE_HANDLER *get_msg_type_handler_by_label(const char *label)
 {
-  json_t *obj;
-
-  obj=json_object_get(jmsg, attr);
-  if (obj == NULL)
-    return TRP_MISSING;
-
-  /* check type */
-  if (!json_is_string(obj))
-    return TRP_BADTYPE;
-
-  *dest=talloc_strdup(mem_ctx, json_string_value(obj));
-  if (*dest==NULL)
-    return TRP_NOMEM;
-
-  return TRP_SUCCESS;
+  size_t ii;
+  for (ii = 0; ii < MAX_MSG_TYPES; ii++) {
+    if (0 == strcmp(label, msg_type_handler_table[ii].msg_type_label))
+      return &(msg_type_handler_table[ii]);
+  }
+  return NULL;
 }
 
-enum msg_type tr_msg_get_msg_type(TR_MSG *msg) 
+TR_MSG_TYPE tr_msg_register_type(const char *msg_type_label,
+                                 TR_MSG_DECODE_FUNC *decode,
+                                 TR_MSG_ENCODE_FUNC *encode)
+{
+  size_t ii;
+  TR_MSG_TYPE_HANDLER *handler;
+
+  if ((!msg_type_label)
+     || (!decode && !encode)) {
+    return TR_MSG_TYPE_UNKNOWN;
+  }
+
+  /* Do we already have a handler for this type? */
+  handler = get_msg_type_handler_by_label(msg_type_label);
+
+  /* if not, add one if we have space */
+  if (!handler) {
+    for(ii = 0; ii < MAX_MSG_TYPES; ii++) {
+      handler = &(msg_type_handler_table[ii]);
+
+      if (TR_MSG_TYPE_UNKNOWN == handler->msg_type)
+        break;
+    }
+
+    /* did we find a slot? */
+    if (ii >= MAX_MSG_TYPES)
+      return -1; /* failed */
+
+    handler->msg_type = ii + 1; /* redundant with the index in this implementation */
+
+    /* make our own copy of the name */
+    strncpy(handler->msg_type_label, msg_type_label, MSG_TYPE_LABEL_LEN);
+    handler->msg_type_label[MSG_TYPE_LABEL_LEN] = '\0'; /* ensure null termination */
+
+  }
+
+  /* fill in or replace the encode/decode functions */
+  handler->decode = decode;
+  handler->encode = encode;
+
+  return handler->msg_type;
+}
+
+
+int tr_msg_set_rep(TR_MSG *msg, void *msg_rep)
+{
+  if (!msg) {
+    tr_err("tr_msg_set_rep: msg is null");
+    return 0;
+  }
+
+  msg->msg_rep = msg_rep;
+  return 1;
+}
+
+void *tr_msg_get_rep(TR_MSG *msg)
+{
+  if (msg)
+    return msg->msg_rep;
+  return NULL;
+}
+
+TR_MSG_TYPE tr_msg_get_msg_type(TR_MSG *msg)
 {
   return msg->msg_type;
 }
 
-void tr_msg_set_msg_type(TR_MSG *msg, enum msg_type type)
+void tr_msg_set_msg_type(TR_MSG *msg, TR_MSG_TYPE type)
 {
   msg->msg_type = type;
 }
 
-/* NOTE: If you are manipulating messages with these getters/setters, the msg_rep
- * objects are *not* put in the talloc context of the msg. If you are allocating
- * the message directly with talloc, then you can talloc_steal() the rep into the
- * message's context, but this is not handled automatically. */
-
-/**
- * Get a TID_REQ message payload
- *
- * @param msg
- * @return the message payload, or null if it is not a TID_REQUEST message
- */
-TID_REQ *tr_msg_get_req(TR_MSG *msg)
-{
-  if (msg->msg_type == TID_REQUEST)
-    return (TID_REQ *)msg->msg_rep;
-  return NULL;
-}
-
-/**
- * Set message's payload
- *
- * Does not manage talloc contexts, works with any means of allocating
- * the objects.
- */
-void tr_msg_set_req(TR_MSG *msg, TID_REQ *req)
-{
-  msg->msg_rep = req;
-  msg->msg_type = TID_REQUEST;
-}
-
-/**
- * Get a TID_RESP message payload
- *
- * @param msg
- * @return the message payload, or null if it is not a TID_RESPONSE message
- */
-TID_RESP *tr_msg_get_resp(TR_MSG *msg)
-{
-  if (msg->msg_type == TID_RESPONSE)
-    return (TID_RESP *)msg->msg_rep;
-  return NULL;
-}
-
-/**
- * Set message's payload
- *
- * Does not manage talloc contexts, works with any means of allocating
- * the objects.
- */
-void tr_msg_set_resp(TR_MSG *msg, TID_RESP *resp)
-{
-  msg->msg_rep = resp;
-  msg->msg_type = TID_RESPONSE;
-}
-
-/**
- * Get a MON_REQ message payload
- *
- * @param msg
- * @return the message payload, or null if it is not a MON_REQUEST message
- */
-MON_REQ *tr_msg_get_mon_req(TR_MSG *msg)
-{
-  if (msg->msg_type == MON_REQUEST)
-    return (MON_REQ *)msg->msg_rep;
-  return NULL;
-}
-
-/**
- * Set message's payload
- *
- * Does not manage talloc contexts, works with any means of allocating
- * the objects.
- */
-void tr_msg_set_mon_req(TR_MSG *msg, MON_REQ *req)
-{
-  msg->msg_rep = req;
-  msg->msg_type = MON_REQUEST;
-}
-
-/**
- * Get a MON_RESP message payload
- *
- * @param msg
- * @return the message payload, or null if it is not a MON_RESPONSE message
- */
-MON_RESP *tr_msg_get_mon_resp(TR_MSG *msg)
-{
-  if (msg->msg_type == MON_RESPONSE)
-    return (MON_RESP *)msg->msg_rep;
-  return NULL;
-}
-
-/**
- * Set message's payload
- *
- * Does not manage talloc contexts, works with any means of allocating
- * the objects.
- */
-void tr_msg_set_mon_resp(TR_MSG *msg, MON_RESP *resp)
-{
-  msg->msg_rep = resp;
-  msg->msg_type = MON_RESPONSE;
-}
-
-/**
- * Get a TRP_UPD message payload
- *
- * @param msg
- * @return the message payload, or null if it is not a TRP_UPDATE message
- */
-TRP_UPD *tr_msg_get_trp_upd(TR_MSG *msg)
-{
-  if (msg->msg_type == TRP_UPDATE)
-    return (TRP_UPD *)msg->msg_rep;
-  return NULL;
-}
-
-/**
- * Set message's payload
- *
- * Does not manage talloc contexts, works with any means of allocating
- * the objects.
- */
-void tr_msg_set_trp_upd(TR_MSG *msg, TRP_UPD *update)
-{
-  msg->msg_rep=update;
-  msg->msg_type=TRP_UPDATE;
-}
-
-/**
- * Get a TRP_REQ message payload
- *
- * @param msg
- * @return the message payload, or null if it is not a TRP_REQUEST message
- */
-TRP_REQ *tr_msg_get_trp_req(TR_MSG *msg)
-{
-  if (msg->msg_type == TRP_REQUEST)
-    return (TRP_REQ *)msg->msg_rep;
-  return NULL;
-}
-
-/**
- * Set message's payload
- *
- * Does not manage talloc contexts, works with any means of allocating
- * the objects.
- */
-void tr_msg_set_trp_req(TR_MSG *msg, TRP_REQ *req)
-{
-  msg->msg_rep=req;
-  msg->msg_type=TRP_REQUEST;
-}
-
-static json_t *tr_msg_encode_dh(DH *dh)
-{
-  json_t *jdh = NULL;
-  json_t *jbn = NULL;
-  char *s=NULL;
-
-  if ((!dh) || (!dh->p) || (!dh->g) || (!dh->pub_key))
-    return NULL;
-
-  jdh = json_object();
-
-  jbn = json_string(s=BN_bn2hex(dh->p));
-  OPENSSL_free(s);
-  json_object_set_new(jdh, "dh_p", jbn);
-
-  jbn = json_string(s=BN_bn2hex(dh->g));
-  OPENSSL_free(s);
-  json_object_set_new(jdh, "dh_g", jbn);
-
-  jbn = json_string(s=BN_bn2hex(dh->pub_key));
-  OPENSSL_free(s);
-  json_object_set_new(jdh, "dh_pub_key", jbn);
-
-  return jdh;
-}
-
-static DH *tr_msg_decode_dh(json_t *jdh)
-{
-  DH *dh = NULL;
-  json_t *jp = NULL;
-  json_t *jg = NULL;
-  json_t *jpub_key = NULL;
-
-  if (!(dh=tr_dh_new())) {
-    tr_crit("tr_msg_decode_dh(): Error allocating DH structure.");
-    return NULL;
-  }
- 
-  /* store required fields from dh object */
-  if ((NULL == (jp = json_object_get(jdh, "dh_p"))) ||
-      (NULL == (jg = json_object_get(jdh, "dh_g"))) ||
-      (NULL == (jpub_key = json_object_get(jdh, "dh_pub_key")))) {
-    tr_debug("tr_msg_decode_dh(): Error parsing dh_info.");
-    tr_dh_destroy(dh);
-    return NULL;
-  }
-
-  BN_hex2bn(&(dh->p), json_string_value(jp));
-  BN_hex2bn(&(dh->g), json_string_value(jg));
-  BN_hex2bn(&(dh->pub_key), json_string_value(jpub_key));
-
-  return dh;
-}
-
-static json_t * tr_msg_encode_tidreq(TID_REQ *req)
-{
-  json_t *jreq = NULL;
-  json_t *jstr = NULL;
-
-  if ((!req) || (!req->rp_realm) || (!req->realm) || !(req->comm))
-    return NULL;
-
-  jreq = json_object();
-  assert(jreq);
-
-  jstr = tr_name_to_json_string(req->rp_realm);
-  json_object_set_new(jreq, "rp_realm", jstr);
-
-  jstr = tr_name_to_json_string(req->realm);
-  json_object_set_new(jreq, "target_realm", jstr);
-
-  jstr = tr_name_to_json_string(req->comm);
-  json_object_set_new(jreq, "community", jstr);
-
-  if (req->orig_coi) {
-    jstr = tr_name_to_json_string(req->orig_coi);
-    json_object_set_new(jreq, "orig_coi", jstr);
-  }
-
-  if (tid_req_get_request_id(req)) {
-    jstr = tr_name_to_json_string(tid_req_get_request_id(req));
-    json_object_set_new(jreq, "request_id", jstr);
-  }
-
-  json_object_set_new(jreq, "dh_info", tr_msg_encode_dh(req->tidc_dh));
-
-  if (req->cons)
-    json_object_set(jreq, "constraints", (json_t *) req->cons);
-
-  if (req->path)
-    json_object_set(jreq, "path", req->path);
-  if (req->expiration_interval)
-    json_object_set_new(jreq, "expiration_interval",
-			json_integer(req->expiration_interval));
-  
-  return jreq;
-}
-
-static TID_REQ *tr_msg_decode_tidreq(TALLOC_CTX *mem_ctx, json_t *jreq)
-{
-  TID_REQ *treq = NULL;
-  json_t *jrp_realm = NULL;
-  json_t *jrealm = NULL;
-  json_t *jcomm = NULL;
-  json_t *jorig_coi = NULL;
-  json_t *jrequest_id = NULL;
-  json_t *jdh = NULL;
-  json_t *jpath = NULL;
-  json_t *jexpire_interval = NULL;
-
-  if (!(treq =tid_req_new())) {
-    tr_crit("tr_msg_decode_tidreq(): Error allocating TID_REQ structure.");
-    return NULL;
-  }
-  talloc_steal(mem_ctx, treq);
-
-  /* store required fields from request */
-  if ((NULL == (jrp_realm = json_object_get(jreq, "rp_realm"))) ||
-      (NULL == (jrealm = json_object_get(jreq, "target_realm"))) ||
-      (NULL == (jcomm = json_object_get(jreq, "community")))) {
-    tr_notice("tr_msg_decode(): Error parsing required fields.");
-    tid_req_free(treq);
-    return NULL;
-  }
-
-  jpath = json_object_get(jreq, "path");
-  jexpire_interval = json_object_get(jreq, "expiration_interval");
-
-  treq->rp_realm = tr_new_name(json_string_value(jrp_realm));
-  treq->realm = tr_new_name(json_string_value(jrealm));
-  treq->comm = tr_new_name(json_string_value(jcomm));
-
-  /* Get DH Info from the request */
-  if (NULL == (jdh = json_object_get(jreq, "dh_info"))) {
-    tr_debug("tr_msg_decode(): Error parsing dh_info.");
-    tid_req_free(treq);
-    return NULL;
-  }
-  treq->tidc_dh = tr_msg_decode_dh(jdh);
-
-  /* store optional "orig_coi" field */
-  if (NULL != (jorig_coi = json_object_get(jreq, "orig_coi"))) {
-    treq->orig_coi = tr_new_name(json_string_value(jorig_coi));
-  }
-
-  /* store optional "request_id" field */
-  if (NULL != (jrequest_id = json_object_get(jreq, "request_id"))) {
-    tid_req_set_request_id(treq, tr_new_name(json_string_value(jrequest_id)));
-  }
-
-  treq->cons = (TR_CONSTRAINT_SET *) json_object_get(jreq, "constraints");
-  if (treq->cons) {
-    if (!tr_constraint_set_validate(treq->cons)) {
-      tr_debug("Constraint set validation failed");
-    tid_req_free(treq);
-    return NULL;
-    }
-    json_incref((json_t *) treq->cons);
-    tid_req_cleanup_json(treq, (json_t *) treq->cons);
-  }
-  if (jpath) {
-    json_incref(jpath);
-    treq->path = jpath;
-    tid_req_cleanup_json(treq, jpath);
-  }
-  if (jexpire_interval)
-    treq->expiration_interval = json_integer_value(jexpire_interval);
-  
-  return treq;
-}
-
-static json_t *tr_msg_encode_one_server(TID_SRVR_BLK *srvr)
-{
-  json_t *jsrvr = NULL;
-  json_t *jstr = NULL;
-  gchar *time_str = g_time_val_to_iso8601(&srvr->key_expiration);
-
-  tr_debug("Encoding one server.");
-
-  jsrvr = json_object();
-
-  jstr = json_string(srvr->aaa_server_addr);
-  json_object_set_new(jsrvr, "server_addr", jstr);
-
-  json_object_set_new(jsrvr,
-		      "key_expiration", json_string(time_str));
-  g_free(time_str);
-  /* Server DH Block */
-  jstr = tr_name_to_json_string(srvr->key_name);
-  json_object_set_new(jsrvr, "key_name", jstr);
-  json_object_set_new(jsrvr, "server_dh", tr_msg_encode_dh(srvr->aaa_server_dh));
-  if (srvr->path)
-    /* The path is owned by the srvr, so grab an extra ref*/
-    json_object_set(jsrvr, "path", (json_t *)(srvr->path));
-  return jsrvr;
-}
-
-static int tr_msg_decode_one_server(json_t *jsrvr, TID_SRVR_BLK *srvr) 
-{
-  json_t *jsrvr_addr = NULL;
-  json_t *jsrvr_kn = NULL;
-  json_t *jsrvr_dh = NULL;
-  json_t *jsrvr_expire = NULL;
-
-  if (jsrvr == NULL)
-    return -1;
-
-
-  if ((NULL == (jsrvr_addr = json_object_get(jsrvr, "server_addr"))) ||
-      (NULL == (jsrvr_kn = json_object_get(jsrvr, "key_name"))) ||
-      (NULL == (jsrvr_dh = json_object_get(jsrvr, "server_dh")))) {
-    tr_notice("tr_msg_decode_one_server(): Error parsing required fields.");
-    return -1;
-  }
-
-  srvr->aaa_server_addr=talloc_strdup(srvr, json_string_value(jsrvr_addr));
-  srvr->key_name = tr_new_name((char *)json_string_value(jsrvr_kn));
-  srvr->aaa_server_dh = tr_msg_decode_dh(jsrvr_dh);
-  tid_srvr_blk_set_path(srvr, (TID_PATH *) json_object_get(jsrvr, "path"));
-  jsrvr_expire = json_object_get(jsrvr, "key_expiration");
-  if (jsrvr_expire && json_is_string(jsrvr_expire)) {
-    if (!g_time_val_from_iso8601(json_string_value(jsrvr_expire),
-				 &srvr->key_expiration))
-      tr_notice("Key expiration %s cannot be parsed", json_string_value(jsrvr_expire));
-  }
-  
-  return 0;
-}
-
-static json_t *tr_msg_encode_servers(TID_RESP *resp)
-{
-  json_t *jservers = NULL;
-  json_t *jsrvr = NULL;
-  TID_SRVR_BLK *srvr = NULL;
-  size_t index;
-
-  jservers = json_array();
-
-  tid_resp_servers_foreach(resp, srvr, index) {
-    if ((NULL == (jsrvr = tr_msg_encode_one_server(srvr))) ||
-	(-1 == json_array_append_new(jservers, jsrvr))) {
-      return NULL;
-    }
-  }
-
-  //  tr_debug("tr_msg_encode_servers(): servers contains:");
-  //  tr_debug("%s", json_dumps(jservers, 0));
-  return jservers;
-}
-
-static TID_SRVR_BLK *tr_msg_decode_servers(TALLOC_CTX *mem_ctx, json_t *jservers)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  TID_SRVR_BLK *servers=NULL;
-  TID_SRVR_BLK *new_srvr=NULL;
-  json_t *jsrvr;
-  size_t i, num_servers;
-
-  num_servers = json_array_size(jservers);
-  tr_debug("tr_msg_decode_servers(): Number of servers = %u.", (unsigned) num_servers);
-  
-  if (0 == num_servers) {
-    tr_debug("tr_msg_decode_servers(): Server array is empty."); 
-    goto cleanup;
-  }
-
-  for (i = 0; i < num_servers; i++) {
-    jsrvr = json_array_get(jservers, i);
-
-    new_srvr=tid_srvr_blk_new(tmp_ctx);
-    if (new_srvr==NULL) {
-      servers=NULL; /* it's all in tmp_ctx, so we can just let go */
-      goto cleanup;
-    }
-    
-    if (0 != tr_msg_decode_one_server(jsrvr, new_srvr)) {
-      servers=NULL; /* it's all in tmp_ctx, so we can just let go */
-      goto cleanup;
-    }
-
-    tid_srvr_blk_add(servers, new_srvr);
-  }
-
-  talloc_steal(mem_ctx, servers);
-
-cleanup:
-  talloc_free(tmp_ctx);
-  return servers;
-}
-
-static json_t * tr_msg_encode_tidresp(TID_RESP *resp)
-{
-  json_t *jresp = NULL;
-  json_t *jstr = NULL;
-  json_t *jservers = NULL;
-
-  if ((!resp) || (!resp->rp_realm) || (!resp->realm) || !(resp->comm))
-    return NULL;
-
-  jresp = json_object();
-
-  if (TID_ERROR == resp->result) {
-    jstr = json_string("error");
-    json_object_set_new(jresp, "result", jstr);
-    if (resp->err_msg) {
-      jstr = tr_name_to_json_string(resp->err_msg);
-      json_object_set_new(jresp, "err_msg", jstr);
-    }
-  }
-  else {
-    jstr = json_string("success");
-    json_object_set_new(jresp, "result", jstr);
-  }
-
-  jstr = tr_name_to_json_string(resp->rp_realm);
-  json_object_set_new(jresp, "rp_realm", jstr);
-
-  jstr = tr_name_to_json_string(resp->realm);
-  json_object_set_new(jresp, "target_realm", jstr);
-
-  jstr = tr_name_to_json_string(resp->comm);
-  json_object_set_new(jresp, "comm", jstr);
-
-  if (resp->orig_coi) {
-    jstr = tr_name_to_json_string(resp->orig_coi);
-    json_object_set_new(jresp, "orig_coi", jstr);
-  }
-
-  if (tid_resp_get_request_id(resp)) {
-    jstr = tr_name_to_json_string(tid_resp_get_request_id(resp));
-    json_object_set_new(jresp, "request_id", jstr);
-  }
-
-  if (NULL == resp->servers) {
-    tr_debug("tr_msg_encode_tidresp(): No servers to encode.");
-  }
-  else {
-    jservers = tr_msg_encode_servers(resp);
-    json_object_set_new(jresp, "servers", jservers);
-  }
-  if (resp->error_path)
-    json_object_set(jresp, "error_path", resp->error_path);
-  
-  
-  return jresp;
-}
-
-static TID_RESP *tr_msg_decode_tidresp(TALLOC_CTX *mem_ctx, json_t *jresp)
-{
-  TID_RESP *tresp = NULL;
-  json_t *jresult = NULL;
-  json_t *jrp_realm = NULL;
-  json_t *jrealm = NULL;
-  json_t *jcomm = NULL;
-  json_t *jorig_coi = NULL;
-  json_t *jrequest_id = NULL;
-  json_t *jservers = NULL;
-  json_t *jerr_msg = NULL;
-
-  if (!(tresp=tid_resp_new(mem_ctx))) {
-    tr_crit("tr_msg_decode_tidresp(): Error allocating TID_RESP structure.");
-    return NULL;
-  }
-
-  /* store required fields from response */
-  if ((NULL == (jresult = json_object_get(jresp, "result"))) ||
-      (!json_is_string(jresult)) ||
-      (NULL == (jrp_realm = json_object_get(jresp, "rp_realm"))) ||
-      (!json_is_string(jrp_realm)) ||
-      (NULL == (jrealm = json_object_get(jresp, "target_realm"))) ||
-      (!json_is_string(jrealm)) ||
-      (NULL == (jcomm = json_object_get(jresp, "comm"))) ||
-      (!json_is_string(jcomm))) {
-    tr_debug("tr_msg_decode_tidresp(): Error parsing response.");
-    talloc_free(tresp);
-    return NULL;
-  }
-
-  if (0 == (strcmp(json_string_value(jresult), "success"))) {
-    tr_debug("tr_msg_decode_tidresp(): Success! result = %s.", json_string_value(jresult));
-    if ((NULL != (jservers = json_object_get(jresp, "servers"))) ||
-	(!json_is_array(jservers))) {
-      tresp->servers = tr_msg_decode_servers(tresp, jservers); 
-    } 
-    else {
-      talloc_free(tresp);
-      return NULL;
-    }
-    tresp->result = TID_SUCCESS;
-  }
-  else {
-    tresp->result = TID_ERROR;
-    tr_debug("tr_msg_decode_tidresp(): Error! result = %s.", json_string_value(jresult));
-    if ((NULL != (jerr_msg = json_object_get(jresp, "err_msg"))) ||
-	(!json_is_string(jerr_msg))) {
-      tresp->err_msg = tr_new_name(json_string_value(jerr_msg));
-    } else
-      tresp->err_msg = tr_new_name("No error message set.");
-
-    if (NULL !=(tresp->error_path = json_object_get(jresp, "error_path")))
-      json_incref(tresp->error_path);
-  }
-
-  tresp->rp_realm = tr_new_name(json_string_value(jrp_realm));
-  tresp->realm = tr_new_name(json_string_value(jrealm));
-  tresp->comm = tr_new_name(json_string_value(jcomm));
-
-  /* store optional "orig_coi" field */
-  if ((NULL != (jorig_coi = json_object_get(jresp, "orig_coi"))) &&
-      json_is_string(jorig_coi)) {
-    tresp->orig_coi = tr_new_name(json_string_value(jorig_coi));
-  }
-
-  /* store optional "request_id" field */
-  if ((NULL != (jrequest_id = json_object_get(jresp, "request_id"))) &&
-      json_is_string(jrequest_id)) {
-    tid_resp_set_request_id(tresp, tr_new_name(json_string_value(jrequest_id)));
-  }
-
-  return tresp;
-}
-
-static json_t *hostname_and_port_to_json(TR_NAME *hostname, int port)
-{
-  char *s_hostname = tr_name_strdup(hostname);
-  char *s;
-  json_t *j;
-
-  if (s_hostname == NULL)
-    return NULL;
-
-  s = talloc_asprintf(NULL, "%s:%d", s_hostname, port);
-  free(s_hostname);
-
-  if (s == NULL)
-    return NULL;
-
-  j = json_string(s);
-  talloc_free(s);
-
-  return j;
-}
-
-/* Information records for TRP update msg
- * requires that jrec already be allocated */
-static TRP_RC tr_msg_encode_inforec_route(json_t *jrec, TRP_INFOREC *rec)
-{
-  json_t *jstr=NULL;
-  json_t *jint=NULL;
-
-  if (rec==NULL)
-    return TRP_BADTYPE;
-
-  if (trp_inforec_get_trust_router(rec)==NULL)
-    return TRP_ERROR;
-
-  jstr=hostname_and_port_to_json(trp_inforec_get_trust_router(rec),
-                                 trp_inforec_get_trust_router_port(rec));
-  if(jstr==NULL)
-    return TRP_NOMEM;
-  json_object_set_new(jrec, "trust_router", jstr);
-
-  jstr=hostname_and_port_to_json(trp_inforec_get_next_hop(rec),
-                                 trp_inforec_get_next_hop_port(rec));
-  if(jstr==NULL)
-    return TRP_NOMEM;
-  json_object_set_new(jrec, "next_hop", jstr);
-
-  jint=json_integer(trp_inforec_get_metric(rec));
-  if(jint==NULL)
-    return TRP_ERROR;
-  json_object_set_new(jrec, "metric", jint);
-
-  jint=json_integer(trp_inforec_get_interval(rec));
-  if(jint==NULL)
-    return TRP_ERROR;
-  json_object_set_new(jrec, "interval", jint);
-
-  return TRP_SUCCESS;
-}
-
-/* returns a json array */
-static json_t *tr_msg_encode_apcs(TR_APC *apcs)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  TR_APC_ITER *iter=tr_apc_iter_new(tmp_ctx);
-  TR_APC *apc=NULL;
-  json_t *jarray=NULL;
-  json_t *jid=NULL;
-
-  if (iter==NULL)
-    goto cleanup;
-
-  jarray=json_array();
-  if (jarray==NULL)
-    goto cleanup;
-
-  for (apc=tr_apc_iter_first(iter, apcs); apc!=NULL; apc=tr_apc_iter_next(iter)) {
-    jid=tr_name_to_json_string(tr_apc_get_id(apc));
-    if ((jid==NULL) || (json_array_append_new(jarray, jid)!=0)) {
-      json_decref(jarray);
-      jarray=NULL;
-      goto cleanup;
-    }
-  }
-  
-cleanup:
-  talloc_free(tmp_ctx);
-  return jarray;
-}
-
-static TR_APC *tr_msg_decode_apcs(TALLOC_CTX *mem_ctx, json_t *jarray, TRP_RC *rc)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  size_t ii=0;
-  TR_APC *apc_list=NULL;
-  TR_APC *new=NULL;
-  json_t *jstr=NULL;
-
-  *rc=TRP_ERROR;
-
-  for (ii=0; ii<json_array_size(jarray); ii++) {
-    jstr=json_array_get(jarray, ii);
-    new=tr_apc_new(tmp_ctx);
-    if ((jstr==NULL) || (new==NULL) || (!json_is_string(jstr))) {
-      apc_list=NULL; /* these are all in tmp_ctx, so they'll still get cleaned up */
-      goto cleanup;
-    }
-
-    tr_apc_set_id(new, tr_new_name(json_string_value(jstr)));
-    if (tr_apc_get_id(new)==NULL) {
-      apc_list=NULL; /* these are all in tmp_ctx, so they'll still get cleaned up */
-      goto cleanup;
-    }
-
-    tr_apc_add(apc_list, new);
-  }
-
-  *rc=TRP_SUCCESS;
-
-  if (apc_list!=NULL)
-    talloc_steal(mem_ctx, apc_list);
-
-cleanup:
-  talloc_free(tmp_ctx);
-  return apc_list;
-}
-
-static TRP_RC tr_msg_encode_inforec_comm(json_t *jrec, TRP_INFOREC *rec)
-{
-  json_t *jstr=NULL;
-  json_t *jint=NULL;
-  json_t *japcs=NULL;
-  const char *sconst=NULL;
-  TR_COMM_TYPE commtype=TR_COMM_UNKNOWN;
-
-  if (rec==NULL)
-    return TRP_BADTYPE;
-
-  commtype=trp_inforec_get_comm_type(rec);
-  if (commtype==TR_COMM_UNKNOWN) {
-    tr_notice("tr_msg_encode_inforec_comm: unknown community type.");
-    return TRP_ERROR;
-  }
-  sconst=tr_comm_type_to_str(commtype);
-  if (sconst==NULL)
-    return TRP_ERROR;
-  jstr=json_string(sconst);
-  if(jstr==NULL)
-    return TRP_ERROR;
-  json_object_set_new(jrec, "type", jstr);
-
-  sconst=tr_realm_role_to_str(trp_inforec_get_role(rec));
-  if (sconst==NULL) {
-    tr_notice("tr_msg_encode_inforec_comm: unknown realm role.");
-    return TRP_ERROR;
-  }
-  jstr=json_string(sconst);
-  if(jstr==NULL)
-    return TRP_ERROR;
-  json_object_set_new(jrec, "role", jstr);
-
-  japcs=tr_msg_encode_apcs(trp_inforec_get_apcs(rec));
-  if (japcs==NULL) {
-    tr_notice("tr_msg_encode_inforec_comm: error encoding APCs.");
-    return TRP_ERROR;
-  }
-  json_object_set_new(jrec, "apcs", japcs);
-  
-
-  if (trp_inforec_get_owner_realm(rec)!=NULL) {
-    jstr=tr_name_to_json_string(trp_inforec_get_owner_realm(rec));
-    if(jstr==NULL)
-      return TRP_ERROR;
-    json_object_set_new(jrec, "owner_realm", jstr);
-  }  
-
-  if (trp_inforec_get_owner_contact(rec)!=NULL) {
-    jstr=tr_name_to_json_string(trp_inforec_get_owner_contact(rec));
-    if(jstr==NULL)
-      return TRP_ERROR;
-    json_object_set_new(jrec, "owner_contact", jstr);
-  }  
-
-  json_object_set(jrec, "provenance", trp_inforec_get_provenance(rec));
-
-  jint=json_integer(trp_inforec_get_interval(rec));
-  if(jint==NULL)
-    return TRP_ERROR;
-  json_object_set_new(jrec, "interval", jint);
-
-  return TRP_SUCCESS;
-}
-
-static json_t *tr_msg_encode_inforec(TRP_INFOREC *rec)
-{
-  json_t *jrec=NULL;
-  json_t *jstr=NULL;
-
-  if ((rec==NULL) || (trp_inforec_get_type(rec)==TRP_INFOREC_TYPE_UNKNOWN))
-    return NULL;
-
-  jrec=json_object();
-  if (jrec==NULL)
-    return NULL;
-
-  jstr=json_string(trp_inforec_type_to_string(trp_inforec_get_type(rec)));
-  if (jstr==NULL) {
-    json_decref(jrec);
-    return NULL;
-  }
-  json_object_set_new(jrec, "record_type", jstr);
-
-  switch (rec->type) {
-  case TRP_INFOREC_TYPE_ROUTE:
-    if (TRP_SUCCESS!=tr_msg_encode_inforec_route(jrec, rec)) {
-      json_decref(jrec);
-      return NULL;
-    }
-    break;
-  case TRP_INFOREC_TYPE_COMMUNITY:
-    if (TRP_SUCCESS!=tr_msg_encode_inforec_comm(jrec, rec)) {
-      json_decref(jrec);
-      return NULL;
-    }
-    break;
-  default:
-    json_decref(jrec);
-    return NULL;
-  }
-  return jrec;
-}
-
-static TRP_RC tr_msg_decode_trp_inforec_route(json_t *jrecord, TRP_INFOREC *rec)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  TRP_RC rc=TRP_ERROR;
-  char *s=NULL;
-  TR_NAME *name;
-  char *hostname;
-  int port;
-  int num=0;
-
-  /* get the trust router */
-  rc=tr_msg_get_json_string(jrecord, "trust_router", &s, tmp_ctx);
-  if (rc != TRP_SUCCESS)
-    goto cleanup;
-
-  hostname = tr_parse_host(tmp_ctx, s, &port);
-  if ((NULL == hostname)
-      || (NULL == (name = tr_new_name(hostname)))
-      || (port < 0)) {
-    rc = TRP_ERROR;
-    goto cleanup;
-  }
-  talloc_free(s); s=NULL;
-  talloc_free(hostname);
-
-  if (port == 0)
-    port = TRP_PORT;
-
-  if (TRP_SUCCESS!= trp_inforec_set_trust_router(rec, name, port)) {
-    rc=TRP_ERROR;
-    goto cleanup;
-  }
-
-  /* Now do the next hop. If it's not present, use the trust_router for backward
-   * compatibility */
-  switch(tr_msg_get_json_string(jrecord, "next_hop", &s, tmp_ctx)) {
-    case TRP_SUCCESS:
-      /* we got a next_hop field */
-      hostname = tr_parse_host(tmp_ctx, s, &port);
-      if ((hostname == NULL)
-          || (NULL == (name = tr_new_name(hostname)))
-          || (port < 0)) {
-        rc = TRP_ERROR;
-        goto cleanup;
-      }
-      break;
-
-    case TRP_MISSING:
-      /* no next_hop field; use the trust router */
-      name = tr_dup_name(trp_inforec_get_trust_router(rec));
-      if (name == NULL) {
-        rc = TRP_ERROR;
-        goto cleanup;
-      }
-      break;
-
-    default:
-      /* something went wrong */
-      rc = TRP_ERROR;
-      goto cleanup;
-  }
-  talloc_free(s); s=NULL;
-
-  if (port == 0)
-    port = TID_PORT;
-
-  if (TRP_SUCCESS!= trp_inforec_set_next_hop(rec, name, port)) {
-    rc=TRP_ERROR;
-    goto cleanup;
-  }
-
-  rc=tr_msg_get_json_integer(jrecord, "metric", &num);
-  if ((rc != TRP_SUCCESS) || (TRP_SUCCESS!=trp_inforec_set_metric(rec,num)))
-    goto cleanup;
-
-  rc=tr_msg_get_json_integer(jrecord, "interval", &num);
-  if ((rc != TRP_SUCCESS) || (TRP_SUCCESS!=trp_inforec_set_interval(rec,num)))
-    goto cleanup;
-
-cleanup:
-  talloc_free(tmp_ctx);
-  return rc;
-}
-
-static TRP_RC tr_msg_decode_trp_inforec_comm(json_t *jrecord, TRP_INFOREC *rec)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  TRP_RC rc=TRP_ERROR;
-  char *s=NULL;
-  int num=0;
-  TR_APC *apcs=NULL;
-
-  rc=tr_msg_get_json_string(jrecord, "type", &s, tmp_ctx);
-  if (rc != TRP_SUCCESS)
-    goto cleanup;
-  if (TRP_SUCCESS!=trp_inforec_set_comm_type(rec, tr_comm_type_from_str(s))) {
-    rc=TRP_ERROR;
-    goto cleanup;
-  }
-  talloc_free(s); s=NULL;
-
-  rc=tr_msg_get_json_string(jrecord, "role", &s, tmp_ctx);
-  if (rc != TRP_SUCCESS)
-    goto cleanup;
-  if (TRP_SUCCESS!=trp_inforec_set_role(rec, tr_realm_role_from_str(s))) {
-    rc=TRP_ERROR;
-    goto cleanup;
-  }
-  talloc_free(s); s=NULL;
-
-  apcs=tr_msg_decode_apcs(rec, json_object_get(jrecord, "apcs"), &rc);
-  if (rc!=TRP_SUCCESS) {
-    rc=TRP_ERROR;
-    goto cleanup;
-  }
-  trp_inforec_set_apcs(rec, apcs);
-
-  rc=tr_msg_get_json_integer(jrecord, "interval", &num);
-  tr_debug("tr_msg_decode_trp_inforec_comm: interval=%u", num);
-  if ((rc != TRP_SUCCESS) || (TRP_SUCCESS!=trp_inforec_set_interval(rec,num)))
-    goto cleanup;
-
-  trp_inforec_set_provenance(rec, json_object_get(jrecord, "provenance"));
-
-  /* optional */
-  rc=tr_msg_get_json_string(jrecord, "owner_realm", &s, tmp_ctx);
-  if (rc == TRP_SUCCESS) {
-    if (TRP_SUCCESS!=trp_inforec_set_owner_realm(rec, tr_new_name(s))) {
-      rc=TRP_ERROR;
-      goto cleanup;
-    }
-    if (s!=NULL) {
-      talloc_free(s);
-      s=NULL;
-    }
-  }
-
-  rc=tr_msg_get_json_string(jrecord, "owner_contact", &s, tmp_ctx);
-  if (rc == TRP_SUCCESS) {
-    if (TRP_SUCCESS!=trp_inforec_set_owner_contact(rec, tr_new_name(s))) {
-      rc=TRP_ERROR;
-      goto cleanup;
-    }
-    if (s!=NULL) {
-      talloc_free(s);
-      s=NULL;
-    }
-  }
-
-cleanup:
-  talloc_free(tmp_ctx);
-  return rc;
-}
-
-/* decode a single record */
-static TRP_INFOREC *tr_msg_decode_trp_inforec(TALLOC_CTX *mem_ctx, json_t *jrecord)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  TRP_INFOREC_TYPE rectype;
-  TRP_INFOREC *rec=NULL;
-  TRP_RC rc=TRP_ERROR;
-  char *s=NULL;
-  
-  if (TRP_SUCCESS!=tr_msg_get_json_string(jrecord, "record_type", &s, tmp_ctx))
-    goto cleanup;
-
-  rectype=trp_inforec_type_from_string(s);
-  talloc_free(s); s=NULL;
-
-  rec=trp_inforec_new(tmp_ctx, rectype);
-  if (rec==NULL) {
-    rc=TRP_NOMEM;
-    goto cleanup;
-  }
-
-  tr_debug("tr_msg_decode_trp_inforec: '%s' record found.", trp_inforec_type_to_string(rec->type));
-
-  switch(trp_inforec_get_type(rec)) {
-  case TRP_INFOREC_TYPE_ROUTE:
-    rc=tr_msg_decode_trp_inforec_route(jrecord, rec);
-    break;
-  case TRP_INFOREC_TYPE_COMMUNITY:
-    rc=tr_msg_decode_trp_inforec_comm(jrecord, rec);
-    break;
-  default:
-    rc=TRP_UNSUPPORTED;
-    goto cleanup;
-  }
-
-  talloc_steal(mem_ctx, rec);
-  rc=TRP_SUCCESS;
-
-cleanup:
-  if (rc != TRP_SUCCESS) {
-    trp_inforec_free(rec);
-    rec=NULL;
-  }
-  talloc_free(tmp_ctx);
-  return rec;
-}
-
-/* TRP update msg */
-static json_t *tr_msg_encode_trp_upd(TRP_UPD *update)
-{
-  json_t *jupdate=NULL;
-  json_t *jrecords=NULL;
-  json_t *jrec=NULL;
-  json_t *jstr=NULL;
-  TRP_INFOREC *rec;
-  char *s=NULL;
-
-  if (update==NULL)
-    return NULL;
-
-  jupdate=json_object();
-  if (jupdate==NULL)
-    return NULL;
-
-  s=tr_name_strdup(trp_upd_get_comm(update));
-  if (s==NULL) {
-    json_decref(jupdate);
-    return NULL;
-  }
-  jstr=json_string(s);
-  free(s);s=NULL;
-  if(jstr==NULL) {
-    json_decref(jupdate);
-    return NULL;
-  }
-  json_object_set_new(jupdate, "community", jstr);
-
-  s=tr_name_strdup(trp_upd_get_realm(update));
-  if (s==NULL) {
-    json_decref(jupdate);
-    return NULL;
-  }
-  jstr=json_string(s);
-  free(s);s=NULL;
-  if(jstr==NULL) {
-    json_decref(jupdate);
-    return NULL;
-  }
-  json_object_set_new(jupdate, "realm", jstr);
-
-  jrecords=json_array();
-  if (jrecords==NULL) {
-    json_decref(jupdate);
-    return NULL;
-  }
-  json_object_set_new(jupdate, "records", jrecords); /* jrecords now a "borrowed" reference */
-  for (rec=trp_upd_get_inforec(update); rec!=NULL; rec=trp_inforec_get_next(rec)) {
-    tr_debug("tr_msg_encode_trp_upd: encoding inforec.");
-    jrec=tr_msg_encode_inforec(rec);
-    if (jrec==NULL) {
-      json_decref(jupdate); /* also decs jrecords and any elements */
-      return NULL;
-    }
-    if (0!=json_array_append_new(jrecords, jrec)) {
-      json_decref(jupdate); /* also decs jrecords and any elements */
-      json_decref(jrec); /* this one did not get added so dec explicitly */
-      return NULL;
-    }
-  }
-
-  return jupdate;
-}
-
-/* Creates a linked list of records in the msg->body talloc context.
- * An error will be returned if any unparseable records are encountered. 
- */
-static TRP_UPD *tr_msg_decode_trp_upd(TALLOC_CTX *mem_ctx, json_t *jupdate)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  json_t *jrecords=NULL;
-  size_t ii=0;
-  TRP_UPD *update=NULL;
-  TRP_INFOREC *new_rec=NULL;
-  TRP_INFOREC *list_tail=NULL;
-  char *s=NULL;
-  TR_NAME *name;
-  TRP_RC rc=TRP_ERROR;
-
-  update=trp_upd_new(tmp_ctx);
-  if (update==NULL) {
-    rc=TRP_NOMEM;
-    goto cleanup;
-  }
-
-  rc=tr_msg_get_json_string(jupdate, "community", &s, tmp_ctx);
-  if (rc != TRP_SUCCESS) {
-    tr_debug("tr_msg_decode_trp_upd: no community in TRP update message.");
-    rc=TRP_NOPARSE;
-    goto cleanup;
-  }
-  name=tr_new_name(s);
-  if (name==NULL) {
-    tr_debug("tr_msg_decode_trp_upd: could not allocate community name.");
-    rc=TRP_NOMEM;
-    goto cleanup;
-  }
-  talloc_free(s); s=NULL;
-  trp_upd_set_comm(update, name);
-
-  rc=tr_msg_get_json_string(jupdate, "realm", &s, tmp_ctx);
-  if (rc != TRP_SUCCESS) {
-    tr_debug("tr_msg_decode_trp_upd: no realm in TRP update message.");
-    rc=TRP_NOPARSE;
-    goto cleanup;
-  }
-  name=tr_new_name(s);
-  if (name==NULL) {
-    tr_debug("tr_msg_decode_trp_upd: could not allocate realm name.");
-    rc=TRP_NOMEM;
-    goto cleanup;
-  }
-  talloc_free(s); s=NULL;
-  trp_upd_set_realm(update, name);
-
-  jrecords=json_object_get(jupdate, "records");
-  if ((jrecords==NULL) || (!json_is_array(jrecords))) {
-    rc=TRP_NOPARSE;
-    goto cleanup;
-  }
-
-  tr_debug("tr_msg_decode_trp_upd: found %d records", json_array_size(jrecords));
-  /* process the array */
-  for (ii=0; ii<json_array_size(jrecords); ii++) {
-    new_rec=tr_msg_decode_trp_inforec(update, json_array_get(jrecords, ii));
-    if (new_rec==NULL) {
-      rc=TRP_NOPARSE;
-      goto cleanup;
-    }
-
-    if (list_tail==NULL)
-      trp_upd_set_inforec(update, new_rec); /* first is a special case */
-    else
-      trp_inforec_set_next(list_tail, new_rec);
-
-    list_tail=new_rec;
-  }
-
-  /* Succeeded. Move new allocations into the correct talloc context */
-  talloc_steal(mem_ctx, update);
-  rc=TRP_SUCCESS;
-
-cleanup:
-  talloc_free(tmp_ctx);
-  if (rc!=TRP_SUCCESS)
-    return NULL;
-  return update;
-}
-
-static json_t *tr_msg_encode_trp_req(TRP_REQ *req)
-{
-  json_t *jbody=NULL;
-  json_t *jstr=NULL;
-  char *s=NULL;
-
-  if (req==NULL)
-    return NULL;
-
-  jbody=json_object();
-  if (jbody==NULL)
-    return NULL;
-
-  if ((NULL==trp_req_get_comm(req))
-     || (NULL==trp_req_get_realm(req))) {
-    json_decref(jbody);
-    return NULL;
-  }
-
-  s=tr_name_strdup(trp_req_get_comm(req)); /* ensures null termination */
-  if (s==NULL) {
-    json_decref(jbody);
-    return NULL;
-  }
-  jstr=json_string(s);
-  free(s); s=NULL;
-  if (jstr==NULL) {
-    json_decref(jbody);
-    return NULL;
-  }
-  json_object_set_new(jbody, "community", jstr);
-    
-  s=tr_name_strdup(trp_req_get_realm(req)); /* ensures null termination */
-  if (s==NULL) {
-    json_decref(jbody);
-    return NULL;
-  }
-  jstr=json_string(s);
-  free(s); s=NULL;
-  if (jstr==NULL) {
-    json_decref(jbody);
-    return NULL;
-  }
-  json_object_set_new(jbody, "realm", jstr);
-
-  return jbody;
-}
-
-static TRP_REQ *tr_msg_decode_trp_req(TALLOC_CTX *mem_ctx, json_t *jreq)
-{
-  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
-  TRP_REQ *req=NULL;
-  char *s=NULL;
-  TRP_RC rc=TRP_ERROR;
-
-  /* check message type and body type for agreement */
-  req=trp_req_new(tmp_ctx);
-  if (req==NULL) {
-    rc=TRP_NOMEM;
-    goto cleanup;
-  }
-
-  rc=tr_msg_get_json_string(jreq, "community", &s, tmp_ctx);
-  if (rc!=TRP_SUCCESS)
-    goto cleanup;
-  trp_req_set_comm(req, tr_new_name(s));
-  talloc_free(s); s=NULL;
-
-  rc=tr_msg_get_json_string(jreq, "realm", &s, tmp_ctx);
-  if (rc!=TRP_SUCCESS)
-    goto cleanup;
-  trp_req_set_realm(req, tr_new_name(s));
-  talloc_free(s); s=NULL;
-
-  rc=TRP_SUCCESS;
-  talloc_steal(mem_ctx, req);
-
-cleanup:
-  talloc_free(tmp_ctx);
-  if (rc!=TRP_SUCCESS)
-    return NULL;
-  return req;
-}
-
 char *tr_msg_encode(TALLOC_CTX *mem_ctx, TR_MSG *msg)
 {
+  TR_MSG_TYPE_HANDLER *handler = NULL;
   json_t *jmsg=NULL;
   json_t *jmsg_type=NULL;
   char *encoded_tmp=NULL;
   char *encoded=NULL;
-  TID_RESP *tidresp=NULL;
-  TID_REQ *tidreq=NULL;
-  TRP_UPD *trpupd=NULL;
-  TRP_REQ *trpreq=NULL;
-  MON_REQ *monreq=NULL;
-  MON_RESP *monresp=NULL;
+
+  handler = get_msg_type_handler(tr_msg_get_msg_type(msg));
+  if (!handler || !(handler->encode))
+    return NULL; /* no encoder for this type */
 
   /* TBD -- add error handling */
   jmsg = json_object();
-
-  switch (msg->msg_type) {
-    case TID_REQUEST:
-      jmsg_type = json_string("tid_request");
-      json_object_set_new(jmsg, "msg_type", jmsg_type);
-      tidreq=tr_msg_get_req(msg);
-      json_object_set_new(jmsg, "msg_body", tr_msg_encode_tidreq(tidreq));
-      break;
-
-    case TID_RESPONSE:
-      jmsg_type = json_string("tid_response");
-      json_object_set_new(jmsg, "msg_type", jmsg_type);
-      tidresp=tr_msg_get_resp(msg);
-      json_object_set_new(jmsg, "msg_body", tr_msg_encode_tidresp(tidresp));
-      break;
-
-    case TRP_UPDATE:
-      jmsg_type = json_string("trp_update");
-      json_object_set_new(jmsg, "msg_type", jmsg_type);
-      trpupd=tr_msg_get_trp_upd(msg);
-      json_object_set_new(jmsg, "msg_body", tr_msg_encode_trp_upd(trpupd));
-      break;
-
-    case TRP_REQUEST:
-      jmsg_type = json_string("trp_request");
-      json_object_set_new(jmsg, "msg_type", jmsg_type);
-      trpreq=tr_msg_get_trp_req(msg);
-      json_object_set_new(jmsg, "msg_body", tr_msg_encode_trp_req(trpreq));
-      break;
-
-    case MON_REQUEST:
-      jmsg_type = json_string("mon_request");
-      json_object_set_new(jmsg, "msg_type", jmsg_type);
-      monreq=tr_msg_get_mon_req(msg);
-      json_object_set_new(jmsg, "msg_body", mon_req_encode(monreq));
-      break;
-
-    case MON_RESPONSE:
-      jmsg_type = json_string("mon_response");
-      json_object_set_new(jmsg, "msg_type", jmsg_type);
-      monresp=tr_msg_get_mon_resp(msg);
-      json_object_set_new(jmsg, "msg_body", mon_resp_encode(monresp));
-      break;
-
-    default:
-      json_decref(jmsg);
-      return NULL;
-  }
+  jmsg_type  = json_string(handler->msg_type_label);
+  json_object_set_new(jmsg, "msg_type", jmsg_type);
+  json_object_set_new(jmsg, "msg_body", handler->encode(msg->msg_rep));
 
   /* We should perhaps use json_set_alloc_funcs to automatically use talloc, but for
    * now, we'll encode to a malloc'ed buffer, then copy that to a talloc'ed buffer. */
@@ -1424,6 +177,7 @@ char *tr_msg_encode(TALLOC_CTX *mem_ctx, TR_MSG *msg)
 
 TR_MSG *tr_msg_decode(TALLOC_CTX *mem_ctx, const char *jbuf, size_t buflen)
 {
+  TR_MSG_TYPE_HANDLER *handler=NULL;
   TR_MSG *msg=NULL;
   json_t *jmsg = NULL;
   json_error_t rc;
@@ -1441,7 +195,7 @@ TR_MSG *tr_msg_decode(TALLOC_CTX *mem_ctx, const char *jbuf, size_t buflen)
     json_decref(jmsg);
     return NULL;
   }
- 
+
   if ((NULL == (jtype = json_object_get(jmsg, "msg_type"))) ||
       (NULL == (jbody = json_object_get(jmsg, "msg_body")))) {
     tr_debug("tr_msg_decode(): Error parsing message header.");
@@ -1452,33 +206,12 @@ TR_MSG *tr_msg_decode(TALLOC_CTX *mem_ctx, const char *jbuf, size_t buflen)
 
   mtype = json_string_value(jtype);
 
-  if (0 == strcmp(mtype, "tid_request")) {
-    msg->msg_type = TID_REQUEST;
-    tr_msg_set_req(msg, tr_msg_decode_tidreq(msg, jbody));
-  }
-  else if (0 == strcmp(mtype, "tid_response")) {
-    msg->msg_type = TID_RESPONSE;
-    tr_msg_set_resp(msg, tr_msg_decode_tidresp(msg, jbody));
-  }
-  else if (0 == strcmp(mtype, "trp_update")) {
-    msg->msg_type = TRP_UPDATE;
-    tr_msg_set_trp_upd(msg, tr_msg_decode_trp_upd(msg, jbody));
-  }
-  else if (0 == strcmp(mtype, "trp_request")) {
-    msg->msg_type = TRP_UPDATE;
-    tr_msg_set_trp_req(msg, tr_msg_decode_trp_req(msg, jbody));
-  }
-  else if (0 == strcmp(mtype, "mon_request")) {
-    msg->msg_type = MON_REQUEST;
-    tr_msg_set_mon_req(msg, mon_req_decode(msg, jbody));
-  }
-  /* We do not currently handle monitoring responses */
-  else if (0 == strcmp(mtype, "mon_response")) {
-    msg->msg_type = MON_RESPONSE;
-    tr_msg_set_mon_resp(msg, mon_resp_decode(msg, jbody));
-  }
-  else {
-    msg->msg_type = TR_UNKNOWN;
+  handler = get_msg_type_handler_by_label(mtype);
+  if (handler && (handler->decode)) {
+    tr_msg_set_msg_type(msg, handler->msg_type);
+    msg->msg_rep = handler->decode(msg, jbody);
+  } else {
+    tr_msg_set_msg_type(msg, TR_MSG_TYPE_UNKNOWN);
     msg->msg_rep = NULL;
   }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.63)
-AC_INIT([trust_router],[3.4.1~3],
+AC_INIT([trust_router],[3.4.1],
 [bugs@project-moonshot.org])
 AC_CONFIG_MACRO_DIR(m4)
 AC_CONFIG_AUX_DIR(build-aux)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.63)
-AC_INIT([trust_router],[3.4.1~2],
+AC_INIT([trust_router],[3.4.1~3],
 [bugs@project-moonshot.org])
 AC_CONFIG_MACRO_DIR(m4)
 AC_CONFIG_AUX_DIR(build-aux)

--- a/include/mon_internal.h
+++ b/include/mon_internal.h
@@ -142,10 +142,10 @@ size_t mon_req_opt_count(MON_REQ *req);
 MON_OPT *mon_req_opt_index(MON_REQ *req, size_t index);
 
 /* mon_req_encode.c */
-json_t *mon_req_encode(MON_REQ *req);
+json_t *mon_req_encode(void *msg_rep);
 
 /* mon_req_decode.c */
-MON_REQ *mon_req_decode(TALLOC_CTX *mem_ctx, json_t *req_json);
+void *mon_req_decode(TALLOC_CTX *mem_ctx, json_t *req_json);
 MON_REQ *mon_req_parse(TALLOC_CTX *mem_ctx, const char *input);
 
 /* mon_resp.c */
@@ -155,10 +155,10 @@ int mon_resp_set_message(MON_RESP *resp, const char *new_msg);
 void mon_resp_set_payload(MON_RESP *resp, json_t *new_payload);
 
 /* mon_resp_encode.c */
-json_t *mon_resp_encode(MON_RESP *resp);
+json_t *mon_resp_encode(void *msg_rep);
 
 /* mon_resp_decode.c */
-MON_RESP * mon_resp_decode(TALLOC_CTX *mem_ctx, json_t *resp_json);
+void * mon_resp_decode(TALLOC_CTX *mem_ctx, json_t *resp_json);
 
 /* mons.c */
 MONS_INSTANCE *mons_new(TALLOC_CTX *mem_ctx);
@@ -177,5 +177,12 @@ MONC_INSTANCE *monc_new(TALLOC_CTX *mem_ctx);
 void monc_free(MONC_INSTANCE *monc);
 int monc_open_connection(MONC_INSTANCE *monc, const char *server, int port);
 MON_RESP *monc_send_request(TALLOC_CTX *mem_ctx, MONC_INSTANCE *monc, MON_REQ *req);
+
+/* mon_tr_msg.c */
+int mon_tr_msg_init(void);
+MON_REQ *tr_msg_get_mon_req(TR_MSG *msg);
+void tr_msg_set_mon_req(TR_MSG *msg, MON_REQ *req);
+MON_RESP *tr_msg_get_mon_resp(TR_MSG *msg);
+void tr_msg_set_mon_resp(TR_MSG *msg, MON_RESP *resp);
 
 #endif //TRUST_ROUTER_MON_REQ_H

--- a/include/mon_internal.h
+++ b/include/mon_internal.h
@@ -180,9 +180,9 @@ MON_RESP *monc_send_request(TALLOC_CTX *mem_ctx, MONC_INSTANCE *monc, MON_REQ *r
 
 /* mon_tr_msg.c */
 int mon_tr_msg_init(void);
-MON_REQ *tr_msg_get_mon_req(TR_MSG *msg);
-void tr_msg_set_mon_req(TR_MSG *msg, MON_REQ *req);
-MON_RESP *tr_msg_get_mon_resp(TR_MSG *msg);
-void tr_msg_set_mon_resp(TR_MSG *msg, MON_RESP *resp);
+MON_REQ *mon_get_tr_msg_req(TR_MSG *msg);
+void mon_set_tr_msg_req(TR_MSG *msg, MON_REQ *req);
+MON_RESP *mon_get_tr_msg_resp(TR_MSG *msg);
+void mon_set_tr_msg_resp(TR_MSG *msg, MON_RESP *resp);
 
 #endif //TRUST_ROUTER_MON_REQ_H

--- a/include/tid_internal.h
+++ b/include/tid_internal.h
@@ -130,4 +130,11 @@ void tid_resp_set_error_path(TID_RESP *resp, json_t *ep);
 
 void tids_sweep_procs(TIDS_INSTANCE *tids);
 
+/* In tid_tr_msg.c */
+int tr_msg_tid_init(void);
+TID_REQ *tr_msg_get_req(TR_MSG *msg);
+void tr_msg_set_req(TR_MSG *msg, TID_REQ *req);
+TID_RESP *tr_msg_get_resp(TR_MSG *msg);
+void tr_msg_set_resp(TR_MSG *msg, TID_RESP *resp);
+
 #endif

--- a/include/tid_internal.h
+++ b/include/tid_internal.h
@@ -131,10 +131,10 @@ void tid_resp_set_error_path(TID_RESP *resp, json_t *ep);
 void tids_sweep_procs(TIDS_INSTANCE *tids);
 
 /* In tid_tr_msg.c */
-int tr_msg_tid_init(void);
-TID_REQ *tr_msg_get_req(TR_MSG *msg);
-void tr_msg_set_req(TR_MSG *msg, TID_REQ *req);
-TID_RESP *tr_msg_get_resp(TR_MSG *msg);
-void tr_msg_set_resp(TR_MSG *msg, TID_RESP *resp);
+int tid_tr_msg_init(void);
+TID_REQ *tid_get_tr_msg_req(TR_MSG *msg);
+void tid_set_tr_msg_req(TR_MSG *msg, TID_REQ *req);
+TID_RESP *tid_get_tr_msg_resp(TR_MSG *msg);
+void tid_set_tr_msg_resp(TR_MSG *msg, TID_RESP *resp);
 
 #endif

--- a/include/tr_filter.h
+++ b/include/tr_filter.h
@@ -145,6 +145,10 @@ typedef TR_LIST_ITER TR_FLINE_ITER;
 #define tr_fline_iter_next(ITER) (tr_list_iter_next(ITER))
 #define tr_fline_add_spec(LINE, SPEC) ((TR_NAME *) tr_list_add((LINE)->specs, (SPEC), 1))
 
+
+/* Function types for handling filter fields generally. All target values
+ * are represented as strings in a TR_NAME. */
+
 /* CMP functions return values like strcmp: 0 on match, <0 on target<val, >0 on target>val */
 typedef int (TR_FILTER_FIELD_CMP)(TR_FILTER_TARGET *target, TR_NAME *val);
 /* get functions return TR_NAME format of the field value. Caller must free it. */

--- a/include/tr_filter.h
+++ b/include/tr_filter.h
@@ -151,13 +151,10 @@ typedef int (TR_FILTER_FIELD_CMP)(TR_FILTER_TARGET *target, TR_NAME *val);
 typedef TR_NAME *(TR_FILTER_FIELD_GET)(TR_FILTER_TARGET *target);
 
 
-/*In tr_constraint.c and exported, but not really a public symbol; needed by tr_filter.c and by tr_constraint.c*/
-int TR_EXPORT tr_prefix_wildcard_match(const char *str, const char *wc_str);
-
 int tr_filter_apply(TR_FILTER_TARGET *target, TR_FILTER *filt, TR_CONSTRAINT_SET **constraints, TR_FILTER_ACTION *out_action);
 
-TR_FILTER_TARGET TR_EXPORT *tr_filter_target_new(TALLOC_CTX *mem_ctx);
-void TR_EXPORT tr_filter_target_free(TR_FILTER_TARGET *target);
+TR_FILTER_TARGET *tr_filter_target_new(TALLOC_CTX *mem_ctx);
+void tr_filter_target_free(TR_FILTER_TARGET *target);
 TR_FILTER_TARGET *tr_filter_target_tid_req(TALLOC_CTX *mem_ctx, TID_REQ *req);
 
 TR_CONSTRAINT_SET *tr_constraint_set_from_fline(TR_FLINE *fline);
@@ -167,7 +164,7 @@ int tr_filter_validate_spec_field(TR_FILTER_TYPE ftype, TR_FSPEC *fspec);
 const char *tr_filter_type_to_string(TR_FILTER_TYPE ftype);
 TR_FILTER_TYPE tr_filter_type_from_string(const char *s);
 
-int TR_EXPORT tr_filter_add_field_handler(TR_FILTER_TYPE ftype,
+int tr_filter_add_field_handler(TR_FILTER_TYPE ftype,
                                           const char *name,
                                           TR_FILTER_FIELD_CMP *cmp,
                                           TR_FILTER_FIELD_GET *get);

--- a/include/tr_msg.h
+++ b/include/tr_msg.h
@@ -42,44 +42,40 @@
 
 typedef struct tr_msg TR_MSG;
 
-enum msg_type {
-  TR_UNKNOWN = 0,
-  TID_REQUEST,
-  TID_RESPONSE,
-  TRP_UPDATE,
-  TRP_REQUEST,
-  MON_REQUEST,
-  MON_RESPONSE
-};
+#define TR_MSG_TYPE_UNKNOWN 0
+typedef unsigned int TR_MSG_TYPE;
 
 /* Union of TR message types to hold message of any type. */
 struct tr_msg {
-  enum msg_type msg_type;
+  TR_MSG_TYPE msg_type;
   void *msg_rep;
 };
 
-/* Accessors */
-enum msg_type tr_msg_get_msg_type(TR_MSG *msg);
-void tr_msg_set_msg_type(TR_MSG *msg, enum msg_type type);
-TID_REQ *tr_msg_get_req(TR_MSG *msg);
-void tr_msg_set_req(TR_MSG *msg, TID_REQ *req);
-TID_RESP *tr_msg_get_resp(TR_MSG *msg);
-void tr_msg_set_resp(TR_MSG *msg, TID_RESP *resp);
-TRP_UPD *tr_msg_get_trp_upd(TR_MSG *msg);
-void tr_msg_set_trp_upd(TR_MSG *msg, TRP_UPD *req);
-TRP_REQ *tr_msg_get_trp_req(TR_MSG *msg);
-void tr_msg_set_trp_req(TR_MSG *msg, TRP_REQ *req);
-MON_REQ *tr_msg_get_mon_req(TR_MSG *msg);
-void tr_msg_set_mon_req(TR_MSG *msg, MON_REQ *req);
-MON_RESP *tr_msg_get_mon_resp(TR_MSG *msg);
-void tr_msg_set_mon_resp(TR_MSG *msg, MON_RESP *resp);
+typedef void *(TR_MSG_DECODE_FUNC)(TALLOC_CTX *, json_t *);
+typedef json_t *(TR_MSG_ENCODE_FUNC)(void *);
 
+#define MSG_TYPE_LABEL_LEN 30
+typedef struct tr_msg_type_handler {
+  TR_MSG_TYPE msg_type;
+  char msg_type_label[MSG_TYPE_LABEL_LEN+1]; /* +1 to allow space for null term */
+  TR_MSG_DECODE_FUNC *decode;
+  TR_MSG_ENCODE_FUNC *encode;
+} TR_MSG_TYPE_HANDLER;
+
+TR_MSG_TYPE tr_msg_register_type(const char *msg_type_label,
+                                 TR_MSG_DECODE_FUNC *decode,
+                                 TR_MSG_ENCODE_FUNC *encode);
+
+/* Accessors */
+int tr_msg_set_rep(TR_MSG *msg, void *msg_rep);
+void *tr_msg_get_rep(TR_MSG *msg);
+TR_MSG_TYPE tr_msg_get_msg_type(TR_MSG *msg);
+void tr_msg_set_msg_type(TR_MSG *msg, TR_MSG_TYPE type);
 
 /* Encoders/Decoders */
 char *tr_msg_encode(TALLOC_CTX *mem_ctx, TR_MSG *msg);
 TR_MSG *tr_msg_decode(TALLOC_CTX *mem_ctx, const char *jmsg, size_t len);
 void tr_msg_free_encoded(char *jmsg);
 void tr_msg_free_decoded(TR_MSG *msg);
-
 
 #endif

--- a/include/tr_util.h
+++ b/include/tr_util.h
@@ -41,7 +41,7 @@
 /* NB, tr_bin_to_hex() is also prototyped in trust_router/tr_dh.h */
 TR_EXPORT void tr_bin_to_hex(const unsigned char * bin, size_t binlen,
                              char * hex_out, size_t hex_len);
-TR_EXPORT int tr_cmp_timespec(const struct timespec *ts1, const struct timespec *ts2);
+int tr_cmp_timespec(const struct timespec *ts1, const struct timespec *ts2);
 int tr_add_timespec(const struct timespec *ts1, const struct timespec *ts2, struct timespec *sum);
 int tr_sub_timespec(const struct timespec *ts1_copy, const struct timespec *ts2_copy, struct timespec *diff);
 char *timespec_to_str(const struct timespec *ts);

--- a/include/trp_internal.h
+++ b/include/trp_internal.h
@@ -105,8 +105,8 @@ typedef struct trps_instance TRPS_INSTANCE;
 
 typedef enum trp_connection_status {
   TRP_CONNECTION_CLOSED=0,
-  TRP_CONNECTION_DOWN,  
-  TRP_CONNECTION_AUTHORIZING,  
+  TRP_CONNECTION_DOWN,
+  TRP_CONNECTION_AUTHORIZING,
   TRP_CONNECTION_UP,
   TRP_CONNECTION_UNKNOWN,
 } TRP_CONNECTION_STATUS;
@@ -305,5 +305,16 @@ TRP_RC trp_inforec_set_role(TRP_INFOREC *rec, TR_REALM_ROLE role);
 TR_APC *trp_inforec_get_apcs(TRP_INFOREC *rec);
 TRP_RC trp_inforec_set_apcs(TRP_INFOREC *rec, TR_APC *apcs);
 TR_NAME *trp_inforec_dup_origin(TRP_INFOREC *rec);
+
+/* From trp_tr_msg.c */
+int tr_msg_trp_init(void);
+TRP_UPD *tr_msg_get_trp_upd(TR_MSG *msg);
+void tr_msg_set_trp_upd(TR_MSG *msg, TRP_UPD *upd);
+TRP_REQ *tr_msg_get_trp_req(TR_MSG *msg);
+void tr_msg_set_trp_req(TR_MSG *msg, TRP_REQ *req);
+
+/* From trp_filter.c */
+void trp_filter_init(void);
+TR_FILTER_TARGET *tr_filter_target_trp_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd, TRP_INFOREC *inforec);
 
 #endif /* TRP_INTERNAL_H */

--- a/include/trp_internal.h
+++ b/include/trp_internal.h
@@ -307,14 +307,14 @@ TRP_RC trp_inforec_set_apcs(TRP_INFOREC *rec, TR_APC *apcs);
 TR_NAME *trp_inforec_dup_origin(TRP_INFOREC *rec);
 
 /* From trp_tr_msg.c */
-int tr_msg_trp_init(void);
-TRP_UPD *tr_msg_get_trp_upd(TR_MSG *msg);
-void tr_msg_set_trp_upd(TR_MSG *msg, TRP_UPD *upd);
-TRP_REQ *tr_msg_get_trp_req(TR_MSG *msg);
-void tr_msg_set_trp_req(TR_MSG *msg, TRP_REQ *req);
+int trp_tr_msg_init(void);
+TRP_UPD *trp_get_tr_msg_upd(TR_MSG *msg);
+void trp_set_tr_msg_upd(TR_MSG *msg, TRP_UPD *upd);
+TRP_REQ *trp_get_tr_msg_req(TR_MSG *msg);
+void trp_set_tr_msg_req(TR_MSG *msg, TRP_REQ *req);
 
 /* From trp_filter.c */
 void trp_filter_init(void);
-TR_FILTER_TARGET *tr_filter_target_trp_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd, TRP_INFOREC *inforec);
+TR_FILTER_TARGET *trp_filter_target_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd, TRP_INFOREC *inforec);
 
 #endif /* TRP_INTERNAL_H */

--- a/include/trust_router/tid.h
+++ b/include/trust_router/tid.h
@@ -81,27 +81,27 @@ TR_EXPORT TID_REQ *tid_req_new(void);
 TR_EXPORT TID_REQ *tid_req_get_next_req(TID_REQ *req);
 void tid_req_set_next_req(TID_REQ *req, TID_REQ *next_req);
 TR_EXPORT int tid_req_get_resp_sent(TID_REQ *req);
-void tid_req_set_resp_sent(TID_REQ *req, int resp_sent);
+TR_EXPORT void tid_req_set_resp_sent(TID_REQ *req, int resp_sent);
 TR_EXPORT int tid_req_get_conn(TID_REQ *req);
-void tid_req_set_conn(TID_REQ *req, int conn);
+TR_EXPORT void tid_req_set_conn(TID_REQ *req, int conn);
 TR_EXPORT gss_ctx_id_t tid_req_get_gssctx(TID_REQ *req);
-void tid_req_set_gssctx(TID_REQ *req, gss_ctx_id_t gssctx);
+TR_EXPORT void tid_req_set_gssctx(TID_REQ *req, gss_ctx_id_t gssctx);
 TR_EXPORT int tid_req_get_resp_rcvd(TID_REQ *req);
-void tid_req_set_resp_rcvd(TID_REQ *req, int resp_rcvd);
+TR_EXPORT void tid_req_set_resp_rcvd(TID_REQ *req, int resp_rcvd);
 TR_EXPORT TR_NAME *tid_req_get_rp_realm(TID_REQ *req);
-void tid_req_set_rp_realm(TID_REQ *req, TR_NAME *rp_realm);
+TR_EXPORT void tid_req_set_rp_realm(TID_REQ *req, TR_NAME *rp_realm);
 TR_EXPORT TR_NAME *tid_req_get_realm(TID_REQ *req);
-void tid_req_set_realm(TID_REQ *req, TR_NAME *realm);
+TR_EXPORT void tid_req_set_realm(TID_REQ *req, TR_NAME *realm);
 TR_EXPORT TR_NAME *tid_req_get_comm(TID_REQ *req);
-void tid_req_set_comm(TID_REQ *req, TR_NAME *comm);
+TR_EXPORT void tid_req_set_comm(TID_REQ *req, TR_NAME *comm);
 TR_EXPORT TR_NAME *tid_req_get_orig_coi(TID_REQ *req);
-void tid_req_set_orig_coi(TID_REQ *req, TR_NAME *orig_coi);
+TR_EXPORT void tid_req_set_orig_coi(TID_REQ *req, TR_NAME *orig_coi);
 TR_EXPORT TR_NAME *tid_req_get_request_id(TID_REQ *req);
-void tid_req_set_request_id(TID_REQ *req, TR_NAME *request_id);
+TR_EXPORT void tid_req_set_request_id(TID_REQ *req, TR_NAME *request_id);
 TR_EXPORT TIDC_RESP_FUNC *tid_req_get_resp_func(TID_REQ *req);
-void tid_req_set_resp_func(TID_REQ *req, TIDC_RESP_FUNC *resp_func);
+TR_EXPORT void tid_req_set_resp_func(TID_REQ *req, TIDC_RESP_FUNC *resp_func);
 TR_EXPORT void *tid_req_get_cookie(TID_REQ *req);
-void tid_req_set_cookie(TID_REQ *req, void *cookie);
+TR_EXPORT void tid_req_set_cookie(TID_REQ *req, void *cookie);
 TR_EXPORT TID_REQ *tid_dup_req (TID_REQ *orig_req);
 TR_EXPORT void tid_req_free( TID_REQ *req);
 
@@ -109,34 +109,36 @@ TR_EXPORT void tid_req_free( TID_REQ *req);
 
 TID_RESP *tid_resp_new(TALLOC_CTX *mem_ctx);
 void tid_resp_free(TID_RESP *resp);
-TID_RESP *tid_resp_dup(TALLOC_CTX *mem_ctx, TID_RESP *resp);
+TR_EXPORT TID_RC tid_resp_cpy(TID_RESP *dst, TID_RESP *src);
+TR_EXPORT TID_RESP *tid_resp_dup(TALLOC_CTX *mem_ctx, TID_RESP *resp);
 TR_EXPORT int tid_resp_get_result(TID_RESP *resp);
-void tid_resp_set_result(TID_RESP *resp, int result);
+TR_EXPORT void tid_resp_set_result(TID_RESP *resp, int result);
 TR_EXPORT TR_NAME *tid_resp_get_err_msg(TID_RESP *resp);
-void tid_resp_set_err_msg(TID_RESP *resp, TR_NAME *err_msg);
+TR_EXPORT void tid_resp_set_err_msg(TID_RESP *resp, TR_NAME *err_msg);
 TR_EXPORT TR_NAME *tid_resp_get_rp_realm(TID_RESP *resp);
-void tid_resp_set_rp_realm(TID_RESP *resp, TR_NAME *rp_realm);
+TR_EXPORT void tid_resp_set_rp_realm(TID_RESP *resp, TR_NAME *rp_realm);
 TR_EXPORT TR_NAME *tid_resp_get_realm(TID_RESP *resp);
-void tid_resp_set_realm(TID_RESP *resp, TR_NAME *realm);
+TR_EXPORT void tid_resp_set_realm(TID_RESP *resp, TR_NAME *realm);
 TR_EXPORT TR_NAME *tid_resp_get_comm(TID_RESP *resp);
-void tid_resp_set_comm(TID_RESP *resp, TR_NAME *comm);
+TR_EXPORT void tid_resp_set_comm(TID_RESP *resp, TR_NAME *comm);
 TR_EXPORT TR_NAME *tid_resp_get_orig_coi(TID_RESP *resp);
-void tid_resp_set_orig_coi(TID_RESP *resp, TR_NAME *orig_coi);
+TR_EXPORT void tid_resp_set_orig_coi(TID_RESP *resp, TR_NAME *orig_coi);
 TR_EXPORT TR_NAME *tid_resp_get_request_id(TID_RESP *resp);
-void tid_resp_set_request_id(TID_RESP *resp, TR_NAME *request_id);
+TR_EXPORT void tid_resp_set_request_id(TID_RESP *resp, TR_NAME *request_id);
 TR_EXPORT TID_SRVR_BLK *tid_resp_get_server(TID_RESP *resp, size_t index);
 TR_EXPORT size_t tid_resp_get_num_servers(const TID_RESP *resp);
-TR_EXPORT const TID_PATH *tid_resp_get_error_path(const TID_RESP *);
+const TID_PATH TR_EXPORT *tid_resp_get_error_path(const TID_RESP *);
+TR_EXPORT void tids_sweep_procs(TIDS_INSTANCE *tids);
 
 /** Get either the error_path or the path of the first server block for
  * a successful response*/
-TR_EXPORT const TID_PATH *tid_resp_get_a_path(const TID_RESP *);
+const TID_PATH TR_EXPORT *tid_resp_get_a_path(const TID_RESP *);
 /* Server blocks*/
 TR_EXPORT void tid_srvr_get_address(const TID_SRVR_BLK *,
 				    const struct sockaddr **out_addr, size_t *out_sa_len);
 TR_EXPORT DH *tid_srvr_get_dh(TID_SRVR_BLK *);
-TR_EXPORT const TR_NAME *tid_srvr_get_key_name(const TID_SRVR_BLK *);
-TR_EXPORT const TID_PATH *tid_srvr_get_path(const TID_SRVR_BLK *);
+const TR_NAME TR_EXPORT *tid_srvr_get_key_name(const TID_SRVR_BLK *);
+const TID_PATH TR_EXPORT *tid_srvr_get_path(const TID_SRVR_BLK *);
 /* Key expiration time is expressed as time since 1970-01-01 00:00:00 UTC */
 TR_EXPORT int tid_srvr_get_key_expiration(const TID_SRVR_BLK *, struct timeval *tv_out);
 
@@ -156,7 +158,7 @@ TR_EXPORT DH *tidc_set_dh(TIDC_INSTANCE *, DH *);
 TR_EXPORT void tidc_destroy(TIDC_INSTANCE *tidc);
 
 /* TID Server functions, in tid/tids.c */
-TIDS_INSTANCE *tids_new(TALLOC_CTX *mem_ctx);
+TR_EXPORT TIDS_INSTANCE *tids_new(TALLOC_CTX *mem_ctx);
 TR_EXPORT TIDS_INSTANCE *tids_create (void);
 TR_EXPORT int tids_start(TIDS_INSTANCE *tids, TIDS_REQ_FUNC *req_handler,
                          tids_auth_func *auth_handler, const char *hostname,

--- a/include/trust_router/tr_constraint.h
+++ b/include/trust_router/tr_constraint.h
@@ -40,6 +40,8 @@
 
 typedef struct tr_constraint TR_CONSTRAINT;
 
+TR_EXPORT TR_CONSTRAINT *tr_constraint_new(TALLOC_CTX *mem_ctx);
+TR_EXPORT void tr_constraint_free(TR_CONSTRAINT *cons);
 void TR_EXPORT tr_constraint_add_to_set (TR_CONSTRAINT_SET **cs, TR_CONSTRAINT *c);
 int TR_EXPORT tr_constraint_set_validate( TR_CONSTRAINT_SET *);
 TR_EXPORT TR_CONSTRAINT_SET *tr_constraint_set_filter(TID_REQ *request,

--- a/include/trust_router/tr_constraint.h
+++ b/include/trust_router/tr_constraint.h
@@ -54,4 +54,8 @@ int TR_EXPORT tr_constraint_set_get_match_strings(TID_REQ *,
                                                   const char * constraint_type,
                                                   tr_const_string **output,
                                                   size_t *output_len);
+
+/* This is not meant to be public, but is in the symbol list for Debian */
+TR_EXPORT int tr_prefix_wildcard_match(const char *str, const char *wc_str);
+
 #endif

--- a/mon/mon_req_decode.c
+++ b/mon/mon_req_decode.c
@@ -134,7 +134,7 @@ MON_REQ *mon_req_parse(TALLOC_CTX *mem_ctx, const char *input)
  * @param req_json reference to JSON request object
  * @return decoded request struct or NULL on failure
  */
-MON_REQ *mon_req_decode(TALLOC_CTX *mem_ctx, json_t *req_json)
+void *mon_req_decode(TALLOC_CTX *mem_ctx, json_t *req_json)
 {
   TALLOC_CTX *tmp_ctx = talloc_new(NULL);
   MON_REQ *req = NULL;

--- a/mon/mon_req_encode.c
+++ b/mon/mon_req_encode.c
@@ -114,8 +114,9 @@ static json_t *mon_opts_encode(GArray *opts)
  * @param req request to encode
  * @return reference to a JSON object
  */
-json_t *mon_req_encode(MON_REQ *req)
+json_t *mon_req_encode(void *msg_rep)
 {
+  MON_REQ *req = (MON_REQ *) msg_rep;
   json_t *req_json = NULL;
   json_t *cmd_json = NULL;
   json_t *opts_json = NULL;
@@ -158,4 +159,3 @@ json_t *mon_req_encode(MON_REQ *req)
   /* That's it, we succeeded */
   return req_json;
 }
-

--- a/mon/mon_resp_decode.c
+++ b/mon/mon_resp_decode.c
@@ -59,7 +59,7 @@
  * @param resp_json reference to JSON request object
  * @return decoded request struct or NULL on failure
  */
-MON_RESP *mon_resp_decode(TALLOC_CTX *mem_ctx, json_t *resp_json)
+void *mon_resp_decode(TALLOC_CTX *mem_ctx, json_t *resp_json)
 {
   TALLOC_CTX *tmp_ctx = talloc_new(NULL);
   MON_RESP *resp = NULL;

--- a/mon/mon_resp_encode.c
+++ b/mon/mon_resp_encode.c
@@ -64,8 +64,9 @@
  * @param resp response to encode
  * @return response as a newly allocated JSON object
  */
-json_t *mon_resp_encode(MON_RESP *resp)
+json_t *mon_resp_encode(void *msg_rep)
 {
+  MON_RESP *resp = (MON_RESP *) msg_rep;
   json_t *resp_json = NULL;
   json_t *jval = NULL;
 

--- a/mon/mon_tr_msg.c
+++ b/mon/mon_tr_msg.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012-2018 , JANET(UK)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JANET(UK) nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <openssl/dh.h>
+#include <openssl/crypto.h>
+#include <jansson.h>
+#include <assert.h>
+#include <talloc.h>
+
+#include <tr_apc.h>
+#include <tr_comm.h>
+#include <trp_internal.h>
+#include <mon_internal.h>
+#include <tr_msg.h>
+#include <tr_util.h>
+#include <tr_name_internal.h>
+#include <trust_router/tr_constraint.h>
+#include <trust_router/tr_dh.h>
+#include <tr_debug.h>
+#include <tr_inet_util.h>
+
+/* Prototypes */
+
+/* Global handle for message types */
+static struct {
+  TR_MSG_TYPE mon_request;
+  TR_MSG_TYPE mon_response;
+} mon_msg_type = {TR_MSG_TYPE_UNKNOWN, TR_MSG_TYPE_UNKNOWN};
+
+/* Must call this before sending or receiving MON messages */
+int mon_tr_msg_init(void)
+{
+  int result = 1; /* 1 is success */
+
+  if (mon_msg_type.mon_request == TR_MSG_TYPE_UNKNOWN) {
+    mon_msg_type.mon_request = tr_msg_register_type("mon_request",
+                                                    mon_req_decode,
+                                                    mon_req_encode);
+    if (mon_msg_type.mon_request == TR_MSG_TYPE_UNKNOWN) {
+      tr_err("mon_tr_msg_init: unable to register MON request message type");
+      result = 0;
+    }
+  }
+
+  if (mon_msg_type.mon_response == TR_MSG_TYPE_UNKNOWN) {
+    mon_msg_type.mon_response = tr_msg_register_type("mon_response",
+                                                     mon_resp_decode,
+                                                     mon_resp_encode);
+    if (mon_msg_type.mon_response == TR_MSG_TYPE_UNKNOWN) {
+      tr_err("mon_tr_msg_init: unable to register MON response message type");
+      result = 0;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Set the message payload to a MON request
+ *
+ * Sets the message type
+ */
+void tr_msg_set_mon_req(TR_MSG *msg, MON_REQ *req)
+{
+  tr_msg_set_msg_type(msg, mon_msg_type.mon_request);
+  tr_msg_set_rep(msg, req);
+}
+
+/**
+ * Get the MON request from a generic TR_MSG
+ *
+ * Returns null if the message is not a MON request
+ */
+MON_REQ *tr_msg_get_mon_req(TR_MSG *msg)
+{
+  if (tr_msg_get_msg_type(msg) == mon_msg_type.mon_request)
+    return (MON_REQ *) tr_msg_get_rep(msg);
+  return NULL;
+}
+
+/**
+ * Set the message payload to a MON response
+ *
+ * Sets the message type
+ */
+void tr_msg_set_mon_resp(TR_MSG *msg, MON_RESP *resp)
+{
+  tr_msg_set_msg_type(msg, mon_msg_type.mon_response);
+  tr_msg_set_rep(msg, resp);
+}
+
+/**
+ * Get the MON response from a generic TR_MSG
+ *
+ * Returns null if the message is not a MON response
+ */
+MON_RESP *tr_msg_get_mon_resp(TR_MSG *msg)
+{
+  if (tr_msg_get_msg_type(msg) == mon_msg_type.mon_response)
+    return (MON_RESP *) tr_msg_get_rep(msg);
+  return NULL;
+}

--- a/mon/mon_tr_msg.c
+++ b/mon/mon_tr_msg.c
@@ -94,7 +94,7 @@ int mon_tr_msg_init(void)
  *
  * Sets the message type
  */
-void tr_msg_set_mon_req(TR_MSG *msg, MON_REQ *req)
+void mon_set_tr_msg_req(TR_MSG *msg, MON_REQ *req)
 {
   tr_msg_set_msg_type(msg, mon_msg_type.mon_request);
   tr_msg_set_rep(msg, req);
@@ -105,7 +105,7 @@ void tr_msg_set_mon_req(TR_MSG *msg, MON_REQ *req)
  *
  * Returns null if the message is not a MON request
  */
-MON_REQ *tr_msg_get_mon_req(TR_MSG *msg)
+MON_REQ *mon_get_tr_msg_req(TR_MSG *msg)
 {
   if (tr_msg_get_msg_type(msg) == mon_msg_type.mon_request)
     return (MON_REQ *) tr_msg_get_rep(msg);
@@ -117,7 +117,7 @@ MON_REQ *tr_msg_get_mon_req(TR_MSG *msg)
  *
  * Sets the message type
  */
-void tr_msg_set_mon_resp(TR_MSG *msg, MON_RESP *resp)
+void mon_set_tr_msg_resp(TR_MSG *msg, MON_RESP *resp)
 {
   tr_msg_set_msg_type(msg, mon_msg_type.mon_response);
   tr_msg_set_rep(msg, resp);
@@ -128,7 +128,7 @@ void tr_msg_set_mon_resp(TR_MSG *msg, MON_RESP *resp)
  *
  * Returns null if the message is not a MON response
  */
-MON_RESP *tr_msg_get_mon_resp(TR_MSG *msg)
+MON_RESP *mon_get_tr_msg_resp(TR_MSG *msg)
 {
   if (tr_msg_get_msg_type(msg) == mon_msg_type.mon_response)
     return (MON_RESP *) tr_msg_get_rep(msg);

--- a/mon/monc.c
+++ b/mon/monc.c
@@ -54,6 +54,8 @@ MONC_INSTANCE *monc_new(TALLOC_CTX *mem_ctx)
     }
 
     monc->gssc->service_name = "trustmonitor";
+
+    mon_tr_msg_init(); /* Prepare to send messages */
   }
   return monc;
 }
@@ -81,7 +83,6 @@ MON_RESP *monc_send_request(TALLOC_CTX *mem_ctx, MONC_INSTANCE *monc, MON_REQ *r
   if (!(msg = talloc_zero(tmp_ctx, TR_MSG)))
     goto cleanup;
 
-  msg->msg_type = MON_REQUEST;
   tr_msg_set_mon_req(msg, req);
 
   resp_msg = tr_gssc_exchange_msgs(tmp_ctx, monc->gssc, msg);

--- a/mon/monc.c
+++ b/mon/monc.c
@@ -83,13 +83,13 @@ MON_RESP *monc_send_request(TALLOC_CTX *mem_ctx, MONC_INSTANCE *monc, MON_REQ *r
   if (!(msg = talloc_zero(tmp_ctx, TR_MSG)))
     goto cleanup;
 
-  tr_msg_set_mon_req(msg, req);
+  mon_set_tr_msg_req(msg, req);
 
   resp_msg = tr_gssc_exchange_msgs(tmp_ctx, monc->gssc, msg);
   if (resp_msg == NULL)
     goto cleanup;
 
-  resp = tr_msg_get_mon_resp(resp_msg);
+  resp = mon_get_tr_msg_resp(resp_msg);
 
   /* if we got a response, steal it from resp_msg's context so we can return it */
   if (resp)

--- a/mon/mons.c
+++ b/mon/mons.c
@@ -100,6 +100,8 @@ MONS_INSTANCE *mons_new(TALLOC_CTX *mem_ctx)
       talloc_free(mons);
       return NULL;
     }
+
+    mon_tr_msg_init(); /* Prepare to send messages */
   }
   return mons;
 }
@@ -126,9 +128,7 @@ static TR_GSS_RC mons_req_cb(TALLOC_CTX *mem_ctx, TR_MSG *req_msg, TR_MSG **resp
   req = tr_msg_get_mon_req(req_msg);
   if (req == NULL) {
     /* this is an internal error */
-    tr_err("mons_req_cb: Received incorrect message type (was %d, expected %d)",
-           tr_msg_get_msg_type(req_msg),
-           MON_REQUEST);
+    tr_err("mons_req_cb: Received incorrect message type");
     /* TODO send an error response */
     goto cleanup;
   }

--- a/mon/mons.c
+++ b/mon/mons.c
@@ -125,7 +125,7 @@ static TR_GSS_RC mons_req_cb(TALLOC_CTX *mem_ctx, TR_MSG *req_msg, TR_MSG **resp
   if (req_msg == NULL)
     goto cleanup;
 
-  req = tr_msg_get_mon_req(req_msg);
+  req = mon_get_tr_msg_req(req_msg);
   if (req == NULL) {
     /* this is an internal error */
     tr_err("mons_req_cb: Received incorrect message type");
@@ -151,7 +151,7 @@ static TR_GSS_RC mons_req_cb(TALLOC_CTX *mem_ctx, TR_MSG *req_msg, TR_MSG **resp
   }
 
   /* Set the response message payload */
-  tr_msg_set_mon_resp(*resp_msg, resp);
+  mon_set_tr_msg_resp(*resp_msg, resp);
 
   /* Put the response message in the caller's context so it does not get freed when we exit */
   talloc_steal(mem_ctx, *resp_msg);

--- a/tid/tid_tr_msg.c
+++ b/tid/tid_tr_msg.c
@@ -1,0 +1,567 @@
+/*
+ * Copyright (c) 2012-2018 , JANET(UK)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JANET(UK) nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <openssl/dh.h>
+#include <openssl/crypto.h>
+#include <jansson.h>
+#include <assert.h>
+#include <talloc.h>
+
+#include <tr_apc.h>
+#include <tr_comm.h>
+#include <trp_internal.h>
+#include <mon_internal.h>
+#include <tr_msg.h>
+#include <tr_util.h>
+#include <tr_name_internal.h>
+#include <trust_router/tr_constraint.h>
+#include <trust_router/tr_dh.h>
+#include <tr_debug.h>
+#include <tr_inet_util.h>
+
+/* Prototypes */
+static json_t *tr_msg_encode_tidreq(void *msg_rep);
+static void *tr_msg_decode_tidreq(TALLOC_CTX *mem_ctx, json_t *jreq);
+static json_t * tr_msg_encode_tidresp(void *msg_rep);
+static void *tr_msg_decode_tidresp(TALLOC_CTX *mem_ctx, json_t *jresp);
+
+/* Global handle for message types */
+static struct {
+  TR_MSG_TYPE tid_request;
+  TR_MSG_TYPE tid_response;
+} tid_msg_type = {TR_MSG_TYPE_UNKNOWN, TR_MSG_TYPE_UNKNOWN};
+
+/* Must call this before sending or receiving TID messages */
+int tr_msg_tid_init(void)
+{
+  int result = 1; /* 1 is success */
+
+  if (tid_msg_type.tid_request == TR_MSG_TYPE_UNKNOWN) {
+    tid_msg_type.tid_request = tr_msg_register_type("tid_request",
+                                                    tr_msg_decode_tidreq,
+                                                    tr_msg_encode_tidreq);
+    if (tid_msg_type.tid_request == TR_MSG_TYPE_UNKNOWN) {
+      tr_err("tr_msg_tid_init: unable to register TID request message type");
+      result = 0;
+    }
+  }
+
+  if (tid_msg_type.tid_response == TR_MSG_TYPE_UNKNOWN) {
+    tid_msg_type.tid_response = tr_msg_register_type("tid_response",
+                                                     tr_msg_decode_tidresp,
+                                                     tr_msg_encode_tidresp);
+    if (tid_msg_type.tid_response == TR_MSG_TYPE_UNKNOWN) {
+      tr_err("tr_msg_tid_init: unable to register TID response message type");
+      result = 0;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Set the message payload to a TID request
+ *
+ * Sets the message type
+ */
+void tr_msg_set_req(TR_MSG *msg, TID_REQ *req)
+{
+  tr_msg_set_msg_type(msg, tid_msg_type.tid_request);
+  tr_msg_set_rep(msg, req);
+}
+
+/**
+ * Get the TID request from a generic TR_MSG
+ *
+ * Returns null if the message is not a TID_REQUEST
+ */
+TID_REQ *tr_msg_get_req(TR_MSG *msg)
+{
+  if (tr_msg_get_msg_type(msg) == tid_msg_type.tid_request)
+    return (TID_REQ *) tr_msg_get_rep(msg);
+  return NULL;
+}
+
+/**
+ * Set the message payload to a TID response
+ *
+ * Sets the message type
+ */
+void tr_msg_set_resp(TR_MSG *msg, TID_RESP *resp)
+{
+  tr_msg_set_msg_type(msg, tid_msg_type.tid_response);
+  tr_msg_set_rep(msg, resp);
+}
+
+/**
+ * Get the TID response from a generic TR_MSG
+ *
+ * Returns null if the message is not a TID response
+ */
+TID_RESP *tr_msg_get_resp(TR_MSG *msg)
+{
+  if (tr_msg_get_msg_type(msg) == tid_msg_type.tid_response)
+    return (TID_RESP *) tr_msg_get_rep(msg);
+  return NULL;
+}
+
+
+
+static json_t *tr_msg_encode_dh(DH *dh)
+{
+  json_t *jdh = NULL;
+  json_t *jbn = NULL;
+  char *s=NULL;
+
+  if ((!dh) || (!dh->p) || (!dh->g) || (!dh->pub_key))
+    return NULL;
+
+  jdh = json_object();
+
+  jbn = json_string(s=BN_bn2hex(dh->p));
+  OPENSSL_free(s);
+  json_object_set_new(jdh, "dh_p", jbn);
+
+  jbn = json_string(s=BN_bn2hex(dh->g));
+  OPENSSL_free(s);
+  json_object_set_new(jdh, "dh_g", jbn);
+
+  jbn = json_string(s=BN_bn2hex(dh->pub_key));
+  OPENSSL_free(s);
+  json_object_set_new(jdh, "dh_pub_key", jbn);
+
+  return jdh;
+}
+
+static DH *tr_msg_decode_dh(json_t *jdh)
+{
+  DH *dh = NULL;
+  json_t *jp = NULL;
+  json_t *jg = NULL;
+  json_t *jpub_key = NULL;
+
+  if (!(dh=tr_dh_new())) {
+    tr_crit("tr_msg_decode_dh(): Error allocating DH structure.");
+    return NULL;
+  }
+
+  /* store required fields from dh object */
+  if ((NULL == (jp = json_object_get(jdh, "dh_p"))) ||
+      (NULL == (jg = json_object_get(jdh, "dh_g"))) ||
+      (NULL == (jpub_key = json_object_get(jdh, "dh_pub_key")))) {
+    tr_debug("tr_msg_decode_dh(): Error parsing dh_info.");
+    tr_dh_destroy(dh);
+    return NULL;
+  }
+
+  BN_hex2bn(&(dh->p), json_string_value(jp));
+  BN_hex2bn(&(dh->g), json_string_value(jg));
+  BN_hex2bn(&(dh->pub_key), json_string_value(jpub_key));
+
+  return dh;
+}
+
+
+static json_t *tr_msg_encode_tidreq(void *msg_rep)
+{
+  TID_REQ *req = (TID_REQ *) msg_rep;
+  json_t *jreq = NULL;
+  json_t *jstr = NULL;
+
+  if ((!req) || (!req->rp_realm) || (!req->realm) || !(req->comm))
+    return NULL;
+
+  jreq = json_object();
+  assert(jreq);
+
+  jstr = tr_name_to_json_string(req->rp_realm);
+  json_object_set_new(jreq, "rp_realm", jstr);
+
+  jstr = tr_name_to_json_string(req->realm);
+  json_object_set_new(jreq, "target_realm", jstr);
+
+  jstr = tr_name_to_json_string(req->comm);
+  json_object_set_new(jreq, "community", jstr);
+
+  if (req->orig_coi) {
+    jstr = tr_name_to_json_string(req->orig_coi);
+    json_object_set_new(jreq, "orig_coi", jstr);
+  }
+
+  if (tid_req_get_request_id(req)) {
+    jstr = tr_name_to_json_string(tid_req_get_request_id(req));
+    json_object_set_new(jreq, "request_id", jstr);
+  }
+
+  json_object_set_new(jreq, "dh_info", tr_msg_encode_dh(req->tidc_dh));
+
+  if (req->cons)
+    json_object_set(jreq, "constraints", (json_t *) req->cons);
+
+  if (req->path)
+    json_object_set(jreq, "path", req->path);
+  if (req->expiration_interval)
+    json_object_set_new(jreq, "expiration_interval",
+			json_integer(req->expiration_interval));
+
+  return jreq;
+}
+
+static void *tr_msg_decode_tidreq(TALLOC_CTX *mem_ctx, json_t *jreq)
+{
+  TID_REQ *treq = NULL;
+  json_t *jrp_realm = NULL;
+  json_t *jrealm = NULL;
+  json_t *jcomm = NULL;
+  json_t *jorig_coi = NULL;
+  json_t *jrequest_id = NULL;
+  json_t *jdh = NULL;
+  json_t *jpath = NULL;
+  json_t *jexpire_interval = NULL;
+
+  if (!(treq =tid_req_new())) {
+    tr_crit("tr_msg_decode_tidreq(): Error allocating TID_REQ structure.");
+    return NULL;
+  }
+  talloc_steal(mem_ctx, treq);
+
+  /* store required fields from request */
+  if ((NULL == (jrp_realm = json_object_get(jreq, "rp_realm"))) ||
+      (NULL == (jrealm = json_object_get(jreq, "target_realm"))) ||
+      (NULL == (jcomm = json_object_get(jreq, "community")))) {
+    tr_notice("tr_msg_decode(): Error parsing required fields.");
+    tid_req_free(treq);
+    return NULL;
+  }
+
+  jpath = json_object_get(jreq, "path");
+  jexpire_interval = json_object_get(jreq, "expiration_interval");
+
+  treq->rp_realm = tr_new_name(json_string_value(jrp_realm));
+  treq->realm = tr_new_name(json_string_value(jrealm));
+  treq->comm = tr_new_name(json_string_value(jcomm));
+
+  /* Get DH Info from the request */
+  if (NULL == (jdh = json_object_get(jreq, "dh_info"))) {
+    tr_debug("tr_msg_decode(): Error parsing dh_info.");
+    tid_req_free(treq);
+    return NULL;
+  }
+  treq->tidc_dh = tr_msg_decode_dh(jdh);
+
+  /* store optional "orig_coi" field */
+  if (NULL != (jorig_coi = json_object_get(jreq, "orig_coi"))) {
+    treq->orig_coi = tr_new_name(json_string_value(jorig_coi));
+  }
+
+  /* store optional "request_id" field */
+  if (NULL != (jrequest_id = json_object_get(jreq, "request_id"))) {
+    tid_req_set_request_id(treq, tr_new_name(json_string_value(jrequest_id)));
+  }
+
+  treq->cons = (TR_CONSTRAINT_SET *) json_object_get(jreq, "constraints");
+  if (treq->cons) {
+    if (!tr_constraint_set_validate(treq->cons)) {
+      tr_debug("Constraint set validation failed");
+    tid_req_free(treq);
+    return NULL;
+    }
+    json_incref((json_t *) treq->cons);
+    tid_req_cleanup_json(treq, (json_t *) treq->cons);
+  }
+  if (jpath) {
+    json_incref(jpath);
+    treq->path = jpath;
+    tid_req_cleanup_json(treq, jpath);
+  }
+  if (jexpire_interval)
+    treq->expiration_interval = json_integer_value(jexpire_interval);
+
+  return (void *)treq;
+}
+
+static json_t *tr_msg_encode_one_server(TID_SRVR_BLK *srvr)
+{
+  json_t *jsrvr = NULL;
+  json_t *jstr = NULL;
+  gchar *time_str = g_time_val_to_iso8601(&srvr->key_expiration);
+
+  tr_debug("Encoding one server.");
+
+  jsrvr = json_object();
+
+  jstr = json_string(srvr->aaa_server_addr);
+  json_object_set_new(jsrvr, "server_addr", jstr);
+
+  json_object_set_new(jsrvr,
+		      "key_expiration", json_string(time_str));
+  g_free(time_str);
+  /* Server DH Block */
+  jstr = tr_name_to_json_string(srvr->key_name);
+  json_object_set_new(jsrvr, "key_name", jstr);
+  json_object_set_new(jsrvr, "server_dh", tr_msg_encode_dh(srvr->aaa_server_dh));
+  if (srvr->path)
+    /* The path is owned by the srvr, so grab an extra ref*/
+    json_object_set(jsrvr, "path", (json_t *)(srvr->path));
+  return jsrvr;
+}
+
+static int tr_msg_decode_one_server(json_t *jsrvr, TID_SRVR_BLK *srvr)
+{
+  json_t *jsrvr_addr = NULL;
+  json_t *jsrvr_kn = NULL;
+  json_t *jsrvr_dh = NULL;
+  json_t *jsrvr_expire = NULL;
+
+  if (jsrvr == NULL)
+    return -1;
+
+
+  if ((NULL == (jsrvr_addr = json_object_get(jsrvr, "server_addr"))) ||
+      (NULL == (jsrvr_kn = json_object_get(jsrvr, "key_name"))) ||
+      (NULL == (jsrvr_dh = json_object_get(jsrvr, "server_dh")))) {
+    tr_notice("tr_msg_decode_one_server(): Error parsing required fields.");
+    return -1;
+  }
+
+  srvr->aaa_server_addr=talloc_strdup(srvr, json_string_value(jsrvr_addr));
+  srvr->key_name = tr_new_name((char *)json_string_value(jsrvr_kn));
+  srvr->aaa_server_dh = tr_msg_decode_dh(jsrvr_dh);
+  tid_srvr_blk_set_path(srvr, (TID_PATH *) json_object_get(jsrvr, "path"));
+  jsrvr_expire = json_object_get(jsrvr, "key_expiration");
+  if (jsrvr_expire && json_is_string(jsrvr_expire)) {
+    if (!g_time_val_from_iso8601(json_string_value(jsrvr_expire),
+				 &srvr->key_expiration))
+      tr_notice("Key expiration %s cannot be parsed", json_string_value(jsrvr_expire));
+  }
+
+  return 0;
+}
+
+static json_t *tr_msg_encode_servers(TID_RESP *resp)
+{
+  json_t *jservers = NULL;
+  json_t *jsrvr = NULL;
+  TID_SRVR_BLK *srvr = NULL;
+  size_t index;
+
+  jservers = json_array();
+
+  tid_resp_servers_foreach(resp, srvr, index) {
+    if ((NULL == (jsrvr = tr_msg_encode_one_server(srvr))) ||
+	(-1 == json_array_append_new(jservers, jsrvr))) {
+      return NULL;
+    }
+  }
+
+  //  tr_debug("tr_msg_encode_servers(): servers contains:");
+  //  tr_debug("%s", json_dumps(jservers, 0));
+  return jservers;
+}
+
+static TID_SRVR_BLK *tr_msg_decode_servers(TALLOC_CTX *mem_ctx, json_t *jservers)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  TID_SRVR_BLK *servers=NULL;
+  TID_SRVR_BLK *new_srvr=NULL;
+  json_t *jsrvr;
+  size_t i, num_servers;
+
+  num_servers = json_array_size(jservers);
+  tr_debug("tr_msg_decode_servers(): Number of servers = %u.", (unsigned) num_servers);
+
+  if (0 == num_servers) {
+    tr_debug("tr_msg_decode_servers(): Server array is empty.");
+    goto cleanup;
+  }
+
+  for (i = 0; i < num_servers; i++) {
+    jsrvr = json_array_get(jservers, i);
+
+    new_srvr=tid_srvr_blk_new(tmp_ctx);
+    if (new_srvr==NULL) {
+      servers=NULL; /* it's all in tmp_ctx, so we can just let go */
+      goto cleanup;
+    }
+
+    if (0 != tr_msg_decode_one_server(jsrvr, new_srvr)) {
+      servers=NULL; /* it's all in tmp_ctx, so we can just let go */
+      goto cleanup;
+    }
+
+    tid_srvr_blk_add(servers, new_srvr);
+  }
+
+  talloc_steal(mem_ctx, servers);
+
+cleanup:
+  talloc_free(tmp_ctx);
+  return servers;
+}
+
+static json_t * tr_msg_encode_tidresp(void *msg_rep)
+{
+  TID_RESP *resp = (TID_RESP *) msg_rep;
+  json_t *jresp = NULL;
+  json_t *jstr = NULL;
+  json_t *jservers = NULL;
+
+  if ((!resp) || (!resp->rp_realm) || (!resp->realm) || !(resp->comm))
+    return NULL;
+
+  jresp = json_object();
+
+  if (TID_ERROR == resp->result) {
+    jstr = json_string("error");
+    json_object_set_new(jresp, "result", jstr);
+    if (resp->err_msg) {
+      jstr = tr_name_to_json_string(resp->err_msg);
+      json_object_set_new(jresp, "err_msg", jstr);
+    }
+  }
+  else {
+    jstr = json_string("success");
+    json_object_set_new(jresp, "result", jstr);
+  }
+
+  jstr = tr_name_to_json_string(resp->rp_realm);
+  json_object_set_new(jresp, "rp_realm", jstr);
+
+  jstr = tr_name_to_json_string(resp->realm);
+  json_object_set_new(jresp, "target_realm", jstr);
+
+  jstr = tr_name_to_json_string(resp->comm);
+  json_object_set_new(jresp, "comm", jstr);
+
+  if (resp->orig_coi) {
+    jstr = tr_name_to_json_string(resp->orig_coi);
+    json_object_set_new(jresp, "orig_coi", jstr);
+  }
+
+  if (tid_resp_get_request_id(resp)) {
+    jstr = tr_name_to_json_string(tid_resp_get_request_id(resp));
+    json_object_set_new(jresp, "request_id", jstr);
+  }
+
+  if (NULL == resp->servers) {
+    tr_debug("tr_msg_encode_tidresp(): No servers to encode.");
+  }
+  else {
+    jservers = tr_msg_encode_servers(resp);
+    json_object_set_new(jresp, "servers", jservers);
+  }
+  if (resp->error_path)
+    json_object_set(jresp, "error_path", resp->error_path);
+
+
+  return jresp;
+}
+
+static void *tr_msg_decode_tidresp(TALLOC_CTX *mem_ctx, json_t *jresp)
+{
+  TID_RESP *tresp = NULL;
+  json_t *jresult = NULL;
+  json_t *jrp_realm = NULL;
+  json_t *jrealm = NULL;
+  json_t *jcomm = NULL;
+  json_t *jorig_coi = NULL;
+  json_t *jrequest_id = NULL;
+  json_t *jservers = NULL;
+  json_t *jerr_msg = NULL;
+
+  if (!(tresp=tid_resp_new(mem_ctx))) {
+    tr_crit("tr_msg_decode_tidresp(): Error allocating TID_RESP structure.");
+    return NULL;
+  }
+
+  /* store required fields from response */
+  if ((NULL == (jresult = json_object_get(jresp, "result"))) ||
+      (!json_is_string(jresult)) ||
+      (NULL == (jrp_realm = json_object_get(jresp, "rp_realm"))) ||
+      (!json_is_string(jrp_realm)) ||
+      (NULL == (jrealm = json_object_get(jresp, "target_realm"))) ||
+      (!json_is_string(jrealm)) ||
+      (NULL == (jcomm = json_object_get(jresp, "comm"))) ||
+      (!json_is_string(jcomm))) {
+    tr_debug("tr_msg_decode_tidresp(): Error parsing response.");
+    talloc_free(tresp);
+    return NULL;
+  }
+
+  if (0 == (strcmp(json_string_value(jresult), "success"))) {
+    tr_debug("tr_msg_decode_tidresp(): Success! result = %s.", json_string_value(jresult));
+    if ((NULL != (jservers = json_object_get(jresp, "servers"))) ||
+	(!json_is_array(jservers))) {
+      tresp->servers = tr_msg_decode_servers(tresp, jservers);
+    }
+    else {
+      talloc_free(tresp);
+      return NULL;
+    }
+    tresp->result = TID_SUCCESS;
+  }
+  else {
+    tresp->result = TID_ERROR;
+    tr_debug("tr_msg_decode_tidresp(): Error! result = %s.", json_string_value(jresult));
+    if ((NULL != (jerr_msg = json_object_get(jresp, "err_msg"))) ||
+	(!json_is_string(jerr_msg))) {
+      tresp->err_msg = tr_new_name(json_string_value(jerr_msg));
+    } else
+      tresp->err_msg = tr_new_name("No error message set.");
+
+    if (NULL !=(tresp->error_path = json_object_get(jresp, "error_path")))
+      json_incref(tresp->error_path);
+  }
+
+  tresp->rp_realm = tr_new_name(json_string_value(jrp_realm));
+  tresp->realm = tr_new_name(json_string_value(jrealm));
+  tresp->comm = tr_new_name(json_string_value(jcomm));
+
+  /* store optional "orig_coi" field */
+  if ((NULL != (jorig_coi = json_object_get(jresp, "orig_coi"))) &&
+      json_is_string(jorig_coi)) {
+    tresp->orig_coi = tr_new_name(json_string_value(jorig_coi));
+  }
+
+  /* store optional "request_id" field */
+  if ((NULL != (jrequest_id = json_object_get(jresp, "request_id"))) &&
+      json_is_string(jrequest_id)) {
+    tid_resp_set_request_id(tresp, tr_new_name(json_string_value(jrequest_id)));
+  }
+
+  return (void *) tresp;
+}

--- a/tid/tidc.c
+++ b/tid/tidc.c
@@ -70,6 +70,8 @@ TIDC_INSTANCE *tidc_create(void)
     tidc->gssc->service_name = "trustidentity";
     tidc->client_dh = NULL;
     talloc_set_destructor((void *)tidc, tidc_destructor);
+
+    tr_msg_tid_init(); /* ensure TR_MSG can handle TID messages */
   }
   return tidc;
 }
@@ -182,7 +184,7 @@ int tidc_fwd_request(TIDC_INSTANCE *tidc,
   if (!(msg = talloc_zero(tmp_ctx, TR_MSG)))
     goto error;
 
-  msg->msg_type = TID_REQUEST;
+  /* Construct the request message */
   tr_msg_set_req(msg, tid_req);
 
 

--- a/tid/tidc.c
+++ b/tid/tidc.c
@@ -71,7 +71,7 @@ TIDC_INSTANCE *tidc_create(void)
     tidc->client_dh = NULL;
     talloc_set_destructor((void *)tidc, tidc_destructor);
 
-    tr_msg_tid_init(); /* ensure TR_MSG can handle TID messages */
+    tid_tr_msg_init(); /* ensure TR_MSG can handle TID messages */
   }
   return tidc;
 }
@@ -185,7 +185,7 @@ int tidc_fwd_request(TIDC_INSTANCE *tidc,
     goto error;
 
   /* Construct the request message */
-  tr_msg_set_req(msg, tid_req);
+  tid_set_tr_msg_req(msg, tid_req);
 
 
   tr_debug( "tidc_fwd_request: Sending TID request\n");
@@ -196,7 +196,7 @@ int tidc_fwd_request(TIDC_INSTANCE *tidc,
     goto error;
 
   /* TBD -- Check if this is actually a valid response */
-  tid_resp = tr_msg_get_resp(resp_msg);
+  tid_resp = tid_get_tr_msg_resp(resp_msg);
   if (tid_resp == NULL) {
     tr_err( "tidc_fwd_request: Error, no response in the response!\n");
     goto error;
@@ -220,7 +220,7 @@ int tidc_fwd_request(TIDC_INSTANCE *tidc,
   if (resp_handler) {
     /* Call the caller's response function. It must copy any data it needs before returning. */
     tr_debug("tidc_fwd_request: calling response callback function.");
-    (*resp_handler)(tidc, tid_req, tr_msg_get_resp(resp_msg), cookie);
+    (*resp_handler)(tidc, tid_req, tid_get_tr_msg_resp(resp_msg), cookie);
   }
 
   goto cleanup;

--- a/tid/tids.c
+++ b/tid/tids.c
@@ -147,7 +147,7 @@ static char *tids_encode_response(TALLOC_CTX *mem_ctx, TID_RESP *resp)
   char *resp_buf = NULL;
 
   /* Construct the response message */
-  tr_msg_set_resp(&mresp, resp);
+  tid_set_tr_msg_resp(&mresp, resp);
 
   /* Encode the message to JSON */
   resp_buf = tr_msg_encode(mem_ctx, &mresp);
@@ -270,7 +270,7 @@ static TR_GSS_RC tids_req_cb(TALLOC_CTX *mem_ctx, TR_MSG *mreq, TR_MSG **mresp, 
   TR_GSS_RC rc = TR_GSS_ERROR;
 
   /* Get a handle on the request itself. Don't free req - it belongs to mreq */
-  req = tr_msg_get_req(mreq);
+  req = tid_get_tr_msg_req(mreq);
   if (NULL == req) {
     /* This isn't a TID Request, just drop it. */
     tr_debug("tids_req_cb: Not a TID request, dropped.");
@@ -300,7 +300,7 @@ static TR_GSS_RC tids_req_cb(TALLOC_CTX *mem_ctx, TR_MSG *mreq, TR_MSG **mresp, 
     goto cleanup;
   }
   /* Now officially assign the response to the message. */
-  tr_msg_set_resp(*mresp, resp);
+  tid_set_tr_msg_resp(*mresp, resp);
 
   /* Handle the request and fill in resp */
   if (tids_handle_request(tids, req, resp) >= 0)
@@ -339,7 +339,7 @@ TIDS_INSTANCE *tids_new(TALLOC_CTX *mem_ctx)
     }
     talloc_set_destructor((void *)tids, tids_destructor);
 
-    tr_msg_tid_init(); /* ensure TR_MSG can handle TID messages */
+    tid_tr_msg_init(); /* ensure TR_MSG can handle TID messages */
   }
   return tids;
 }

--- a/tid/tids.c
+++ b/tid/tids.c
@@ -67,7 +67,7 @@ static TID_RESP *tids_create_response(TALLOC_CTX *mem_ctx, TID_REQ *req)
     tr_crit("tids_create_response: Error allocating response structure.");
     return NULL;
   }
-  
+
   resp->result = TID_SUCCESS; /* presume success */
   if ((NULL == (resp->rp_realm = tr_dup_name(req->rp_realm))) ||
       (NULL == (resp->realm = tr_dup_name(req->realm))) ||
@@ -115,7 +115,7 @@ static int tids_handle_request(TIDS_INSTANCE *tids, TID_REQ *req, TID_RESP *resp
 
   tr_debug("tids_handle_request: adding self to req path.");
   tid_req_add_path(req, tids->hostname, tids->tids_port);
-  
+
   /* Call the caller's request handler */
   /* TBD -- Handle different error returns/msgs */
   if (0 > (rc = (*tids->req_handler)(tids, req, resp, tids->cookie))) {
@@ -130,7 +130,7 @@ static int tids_handle_request(TIDS_INSTANCE *tids, TID_REQ *req, TID_RESP *resp
     tid_resp_set_result(resp, TID_SUCCESS);
     resp->err_msg = NULL;	/* No error msg on successful return */
   }
-    
+
   return rc;
 }
 
@@ -147,7 +147,6 @@ static char *tids_encode_response(TALLOC_CTX *mem_ctx, TID_RESP *resp)
   char *resp_buf = NULL;
 
   /* Construct the response message */
-  mresp.msg_type = TID_RESPONSE;
   tr_msg_set_resp(&mresp, resp);
 
   /* Encode the message to JSON */
@@ -270,15 +269,14 @@ static TR_GSS_RC tids_req_cb(TALLOC_CTX *mem_ctx, TR_MSG *mreq, TR_MSG **mresp, 
   TID_RESP *resp = NULL;
   TR_GSS_RC rc = TR_GSS_ERROR;
 
-  /* If this isn't a TID Request, just drop it. */
-  if (mreq->msg_type != TID_REQUEST) {
+  /* Get a handle on the request itself. Don't free req - it belongs to mreq */
+  req = tr_msg_get_req(mreq);
+  if (NULL == req) {
+    /* This isn't a TID Request, just drop it. */
     tr_debug("tids_req_cb: Not a TID request, dropped.");
     rc = TR_GSS_INTERNAL_ERROR;
     goto cleanup;
   }
-
-  /* Get a handle on the request itself. Don't free req - it belongs to mreq */
-  req = tr_msg_get_req(mreq);
 
   /* Allocate a response message */
   *mresp = talloc(tmp_ctx, TR_MSG);
@@ -340,6 +338,8 @@ TIDS_INSTANCE *tids_new(TALLOC_CTX *mem_ctx)
       return NULL;
     }
     talloc_set_destructor((void *)tids, tids_destructor);
+
+    tr_msg_tid_init(); /* ensure TR_MSG can handle TID messages */
   }
   return tids;
 }
@@ -377,7 +377,7 @@ nfds_t tids_get_listener(TIDS_INSTANCE *tids,
   else {
     /* opening port succeeded */
     tr_info("tids_get_listener: Opened port %d.", port);
-    
+
     /* make this socket non-blocking */
     for (ii=0; ii<n_fd; ii++) {
       if (0 != fcntl(fd_out[ii], F_SETFL, O_NONBLOCK)) {

--- a/trp/trp_filter.c
+++ b/trp/trp_filter.c
@@ -1,0 +1,283 @@
+#include <stdlib.h>
+#include <string.h>
+#include <talloc.h>
+#include <assert.h>
+
+#include <tr_filter.h>
+#include <trp_internal.h>
+#include <tid_internal.h>
+#include <tr_inet_util.h>
+#include <tr_debug.h>
+
+/**
+ * Create a filter target for a TRP inforec. Does not change the context of the inforec or duplicate TR_NAMEs,
+ * so this is only valid until those are freed.
+ *
+ * @param mem_ctx talloc context for the object
+ * @param upd Update containing the TRP inforec
+ * @param inforec TRP inforec
+ * @return pointer to a TR_FILTER_TARGET structure, or null on allocation failure
+ */
+TR_FILTER_TARGET *tr_filter_target_trp_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd, TRP_INFOREC *inforec)
+{
+  TR_FILTER_TARGET *target=tr_filter_target_new(mem_ctx);
+  if (target) {
+    target->trp_inforec = inforec; /* borrowed, not adding to our context */
+    target->trp_upd=upd;
+  }
+  return target;
+}
+
+/** Handler functions for TRP info_type field */
+static int tr_ff_cmp_trp_info_type(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  TRP_INFOREC *inforec=target->trp_inforec;
+  char *valstr=NULL;
+  int val_type=0;
+
+  assert(val);
+  assert(inforec);
+
+  /* nothing matches unknown */
+  if (inforec->type==TRP_INFOREC_TYPE_UNKNOWN)
+    return 0;
+
+  valstr = tr_name_strdup(val); /* get this as an official null-terminated string */
+  val_type = trp_inforec_type_from_string(valstr);
+  free(valstr);
+
+  /* we do not define an ordering of info types */
+  return (val_type==inforec->type);
+}
+
+static TR_NAME *tr_ff_get_trp_info_type(TR_FILTER_TARGET *target)
+{
+  TRP_INFOREC *inforec=target->trp_inforec;
+  return tr_new_name(trp_inforec_type_to_string(inforec->type));
+}
+
+/** Handlers for TRP realm field */
+static int tr_ff_cmp_trp_realm(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  return tr_name_cmp(trp_upd_get_realm(target->trp_upd), val);
+}
+
+static TR_NAME *tr_ff_get_trp_realm(TR_FILTER_TARGET *target)
+{
+  return tr_dup_name(trp_upd_get_realm(target->trp_upd));
+}
+
+/** Handlers for TRP community field */
+static int tr_ff_cmp_trp_comm(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  return tr_name_cmp(trp_upd_get_comm(target->trp_upd), val);
+}
+
+static TR_NAME *tr_ff_get_trp_comm(TR_FILTER_TARGET *target)
+{
+  return tr_dup_name(trp_upd_get_comm(target->trp_upd));
+}
+
+/** Handlers for TRP community_type field */
+static TR_NAME *tr_ff_get_trp_comm_type(TR_FILTER_TARGET *target)
+{
+  TR_NAME *type=NULL;
+
+  switch(trp_inforec_get_comm_type(target->trp_inforec)) {
+    case TR_COMM_APC:
+      type=tr_new_name("apc");
+      break;
+    case TR_COMM_COI:
+      type=tr_new_name("coi");
+      break;
+    default:
+      type=NULL;
+      break; /* unknown types always fail */
+  }
+
+  return type;
+}
+
+static int tr_ff_cmp_trp_comm_type(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  TR_NAME *type=tr_ff_get_trp_comm_type(target);
+  int retval=0;
+
+  if (type==NULL)
+    retval=1;
+  else {
+    retval = tr_name_cmp(val, type);
+    tr_free_name(type);
+  }
+  return retval;
+}
+
+/** Handlers for TRP realm_role field */
+static TR_NAME *tr_ff_get_trp_realm_role(TR_FILTER_TARGET *target)
+{
+  TR_NAME *type=NULL;
+
+  switch(trp_inforec_get_role(target->trp_inforec)) {
+    case TR_ROLE_IDP:
+      type=tr_new_name("idp");
+      break;
+    case TR_ROLE_RP:
+      type=tr_new_name("rp");
+      break;
+    default:
+      type=NULL;
+      break; /* unknown types always fail */
+  }
+
+  return type;
+}
+
+static int tr_ff_cmp_trp_realm_role(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  TR_NAME *type=tr_ff_get_trp_realm_role(target);
+  int retval=0;
+
+  if (type==NULL)
+    retval=1;
+  else {
+    retval = tr_name_cmp(val, type);
+    tr_free_name(type);
+  }
+  return retval;
+}
+
+/** Handlers for TRP apc field */
+/* TODO: Handle multiple APCs, not just the first */
+static int tr_ff_cmp_trp_apc(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  return tr_name_cmp(tr_apc_get_id(trp_inforec_get_apcs(target->trp_inforec)), val);
+}
+
+static TR_NAME *tr_ff_get_trp_apc(TR_FILTER_TARGET *target)
+{
+  TR_APC *apc=trp_inforec_get_apcs(target->trp_inforec);
+  if (apc==NULL)
+    return NULL;
+
+  return tr_dup_name(tr_apc_get_id(apc));
+}
+
+/** Handlers for TRP owner_realm field */
+static int tr_ff_cmp_trp_owner_realm(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  return tr_name_cmp(trp_inforec_get_owner_realm(target->trp_inforec), val);
+}
+
+static TR_NAME *tr_ff_get_trp_owner_realm(TR_FILTER_TARGET *target)
+{
+  return tr_dup_name(trp_inforec_get_owner_realm(target->trp_inforec));
+}
+
+/** Generic handlers for host:port fields*/
+static TR_NAME *tr_ff_get_hostname_and_port(TR_NAME *hn, int port)
+{
+  return tr_hostname_and_port_to_name(hn, port);
+}
+
+static int tr_ff_cmp_hostname_and_port(TR_NAME *hn, int port, int default_port, TR_NAME *val)
+{
+  int cmp = -1;
+  TR_NAME *n = NULL;
+
+  /* allow a match without :port if the default port is in use */
+  if ((port == default_port) && (tr_name_cmp(hn, val) == 0))
+    return 0;
+
+  /* need to match with the :port */
+  n = tr_ff_get_hostname_and_port(hn, port);
+
+  if (n) {
+    cmp = tr_name_cmp(n, val);
+    tr_free_name(n);
+  }
+  return cmp;
+}
+
+/** Handlers for TRP trust_router field */
+static int tr_ff_cmp_trp_trust_router(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  return tr_ff_cmp_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
+                                     trp_inforec_get_trust_router_port(target->trp_inforec),
+                                     TRP_PORT,
+                                     val);
+}
+
+static TR_NAME *tr_ff_get_trp_trust_router(TR_FILTER_TARGET *target)
+{
+  return tr_ff_get_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
+                                     trp_inforec_get_trust_router_port(target->trp_inforec));
+}
+
+/** Handlers for TRP next_hop field */
+static int tr_ff_cmp_trp_next_hop(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  return tr_ff_cmp_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
+                                     trp_inforec_get_next_hop_port(target->trp_inforec),
+                                     TID_PORT,
+                                     val);
+}
+
+static TR_NAME *tr_ff_get_trp_next_hop(TR_FILTER_TARGET *target)
+{
+  return tr_ff_get_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
+                                     trp_inforec_get_next_hop_port(target->trp_inforec));
+}
+
+/** Handlers for TRP owner_contact field */
+static int tr_ff_cmp_trp_owner_contact(TR_FILTER_TARGET *target, TR_NAME *val)
+{
+  return tr_name_cmp(trp_inforec_get_owner_contact(target->trp_inforec), val);
+}
+
+static TR_NAME *tr_ff_get_trp_owner_contact(TR_FILTER_TARGET *target)
+{
+  return tr_dup_name(trp_inforec_get_owner_contact(target->trp_inforec));
+}
+
+void trp_filter_init(void)
+{
+  /* realm */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "realm", tr_ff_cmp_trp_realm, tr_ff_get_trp_realm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "realm", tr_ff_cmp_trp_realm, tr_ff_get_trp_realm);
+
+  /* community */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "comm", tr_ff_cmp_trp_comm, tr_ff_get_trp_comm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "comm", tr_ff_cmp_trp_comm, tr_ff_get_trp_comm);
+
+  /* community type */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "comm_type", tr_ff_cmp_trp_comm_type, tr_ff_get_trp_comm_type);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "comm_type", tr_ff_cmp_trp_comm_type, tr_ff_get_trp_comm_type);
+
+  /* realm role */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "realm_role", tr_ff_cmp_trp_realm_role, tr_ff_get_trp_realm_role);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "realm_role", tr_ff_cmp_trp_realm_role, tr_ff_get_trp_realm_role);
+
+  /* apc */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "apc", tr_ff_cmp_trp_apc, tr_ff_get_trp_apc);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "apc", tr_ff_cmp_trp_apc, tr_ff_get_trp_apc);
+
+  /* trust_router */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "trust_router", tr_ff_cmp_trp_trust_router, tr_ff_get_trp_trust_router);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "trust_router", tr_ff_cmp_trp_trust_router, tr_ff_get_trp_trust_router);
+
+  /* next_hop */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "next_hop", tr_ff_cmp_trp_next_hop, tr_ff_get_trp_next_hop);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "next_hop", tr_ff_cmp_trp_next_hop, tr_ff_get_trp_next_hop);
+
+  /* owner_realm */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "owner_realm", tr_ff_cmp_trp_owner_realm, tr_ff_get_trp_owner_realm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "owner_realm", tr_ff_cmp_trp_owner_realm, tr_ff_get_trp_owner_realm);
+
+  /* owner_contact */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "owner_contact", tr_ff_cmp_trp_owner_contact, tr_ff_get_trp_owner_contact);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "owner_contact", tr_ff_cmp_trp_owner_contact, tr_ff_get_trp_owner_contact);
+
+  /* info_type */
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "info_type", tr_ff_cmp_trp_info_type, tr_ff_get_trp_info_type);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "info_type", tr_ff_cmp_trp_info_type, tr_ff_get_trp_info_type);
+}

--- a/trp/trp_filter.c
+++ b/trp/trp_filter.c
@@ -18,7 +18,7 @@
  * @param inforec TRP inforec
  * @return pointer to a TR_FILTER_TARGET structure, or null on allocation failure
  */
-TR_FILTER_TARGET *tr_filter_target_trp_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd, TRP_INFOREC *inforec)
+TR_FILTER_TARGET *trp_filter_target_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd, TRP_INFOREC *inforec)
 {
   TR_FILTER_TARGET *target=tr_filter_target_new(mem_ctx);
   if (target) {
@@ -29,7 +29,7 @@ TR_FILTER_TARGET *tr_filter_target_trp_inforec(TALLOC_CTX *mem_ctx, TRP_UPD *upd
 }
 
 /** Handler functions for TRP info_type field */
-static int tr_ff_cmp_trp_info_type(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_info_type(TR_FILTER_TARGET *target, TR_NAME *val)
 {
   TRP_INFOREC *inforec=target->trp_inforec;
   char *valstr=NULL;
@@ -50,36 +50,36 @@ static int tr_ff_cmp_trp_info_type(TR_FILTER_TARGET *target, TR_NAME *val)
   return (val_type==inforec->type);
 }
 
-static TR_NAME *tr_ff_get_trp_info_type(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_info_type(TR_FILTER_TARGET *target)
 {
   TRP_INFOREC *inforec=target->trp_inforec;
   return tr_new_name(trp_inforec_type_to_string(inforec->type));
 }
 
 /** Handlers for TRP realm field */
-static int tr_ff_cmp_trp_realm(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_realm(TR_FILTER_TARGET *target, TR_NAME *val)
 {
   return tr_name_cmp(trp_upd_get_realm(target->trp_upd), val);
 }
 
-static TR_NAME *tr_ff_get_trp_realm(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_realm(TR_FILTER_TARGET *target)
 {
   return tr_dup_name(trp_upd_get_realm(target->trp_upd));
 }
 
 /** Handlers for TRP community field */
-static int tr_ff_cmp_trp_comm(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_comm(TR_FILTER_TARGET *target, TR_NAME *val)
 {
   return tr_name_cmp(trp_upd_get_comm(target->trp_upd), val);
 }
 
-static TR_NAME *tr_ff_get_trp_comm(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_comm(TR_FILTER_TARGET *target)
 {
   return tr_dup_name(trp_upd_get_comm(target->trp_upd));
 }
 
 /** Handlers for TRP community_type field */
-static TR_NAME *tr_ff_get_trp_comm_type(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_comm_type(TR_FILTER_TARGET *target)
 {
   TR_NAME *type=NULL;
 
@@ -98,9 +98,9 @@ static TR_NAME *tr_ff_get_trp_comm_type(TR_FILTER_TARGET *target)
   return type;
 }
 
-static int tr_ff_cmp_trp_comm_type(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_comm_type(TR_FILTER_TARGET *target, TR_NAME *val)
 {
-  TR_NAME *type=tr_ff_get_trp_comm_type(target);
+  TR_NAME *type= trp_ff_get_comm_type(target);
   int retval=0;
 
   if (type==NULL)
@@ -113,7 +113,7 @@ static int tr_ff_cmp_trp_comm_type(TR_FILTER_TARGET *target, TR_NAME *val)
 }
 
 /** Handlers for TRP realm_role field */
-static TR_NAME *tr_ff_get_trp_realm_role(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_realm_role(TR_FILTER_TARGET *target)
 {
   TR_NAME *type=NULL;
 
@@ -132,9 +132,9 @@ static TR_NAME *tr_ff_get_trp_realm_role(TR_FILTER_TARGET *target)
   return type;
 }
 
-static int tr_ff_cmp_trp_realm_role(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_realm_role(TR_FILTER_TARGET *target, TR_NAME *val)
 {
-  TR_NAME *type=tr_ff_get_trp_realm_role(target);
+  TR_NAME *type= trp_ff_get_realm_role(target);
   int retval=0;
 
   if (type==NULL)
@@ -148,12 +148,12 @@ static int tr_ff_cmp_trp_realm_role(TR_FILTER_TARGET *target, TR_NAME *val)
 
 /** Handlers for TRP apc field */
 /* TODO: Handle multiple APCs, not just the first */
-static int tr_ff_cmp_trp_apc(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_trp_apc(TR_FILTER_TARGET *target, TR_NAME *val)
 {
   return tr_name_cmp(tr_apc_get_id(trp_inforec_get_apcs(target->trp_inforec)), val);
 }
 
-static TR_NAME *tr_ff_get_trp_apc(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_apc(TR_FILTER_TARGET *target)
 {
   TR_APC *apc=trp_inforec_get_apcs(target->trp_inforec);
   if (apc==NULL)
@@ -163,23 +163,23 @@ static TR_NAME *tr_ff_get_trp_apc(TR_FILTER_TARGET *target)
 }
 
 /** Handlers for TRP owner_realm field */
-static int tr_ff_cmp_trp_owner_realm(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_owner_realm(TR_FILTER_TARGET *target, TR_NAME *val)
 {
   return tr_name_cmp(trp_inforec_get_owner_realm(target->trp_inforec), val);
 }
 
-static TR_NAME *tr_ff_get_trp_owner_realm(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_owner_realm(TR_FILTER_TARGET *target)
 {
   return tr_dup_name(trp_inforec_get_owner_realm(target->trp_inforec));
 }
 
 /** Generic handlers for host:port fields*/
-static TR_NAME *tr_ff_get_hostname_and_port(TR_NAME *hn, int port)
+static TR_NAME *trp_ff_get_hostname_and_port(TR_NAME *hn, int port)
 {
   return tr_hostname_and_port_to_name(hn, port);
 }
 
-static int tr_ff_cmp_hostname_and_port(TR_NAME *hn, int port, int default_port, TR_NAME *val)
+static int trp_ff_cmp_hostname_and_port(TR_NAME *hn, int port, int default_port, TR_NAME *val)
 {
   int cmp = -1;
   TR_NAME *n = NULL;
@@ -189,7 +189,7 @@ static int tr_ff_cmp_hostname_and_port(TR_NAME *hn, int port, int default_port, 
     return 0;
 
   /* need to match with the :port */
-  n = tr_ff_get_hostname_and_port(hn, port);
+  n = trp_ff_get_hostname_and_port(hn, port);
 
   if (n) {
     cmp = tr_name_cmp(n, val);
@@ -199,42 +199,42 @@ static int tr_ff_cmp_hostname_and_port(TR_NAME *hn, int port, int default_port, 
 }
 
 /** Handlers for TRP trust_router field */
-static int tr_ff_cmp_trp_trust_router(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_trust_router(TR_FILTER_TARGET *target, TR_NAME *val)
 {
-  return tr_ff_cmp_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
-                                     trp_inforec_get_trust_router_port(target->trp_inforec),
-                                     TRP_PORT,
-                                     val);
+  return trp_ff_cmp_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
+                                      trp_inforec_get_trust_router_port(target->trp_inforec),
+                                      TRP_PORT,
+                                      val);
 }
 
-static TR_NAME *tr_ff_get_trp_trust_router(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_trust_router(TR_FILTER_TARGET *target)
 {
-  return tr_ff_get_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
-                                     trp_inforec_get_trust_router_port(target->trp_inforec));
+  return trp_ff_get_hostname_and_port(trp_inforec_get_trust_router(target->trp_inforec),
+                                      trp_inforec_get_trust_router_port(target->trp_inforec));
 }
 
 /** Handlers for TRP next_hop field */
-static int tr_ff_cmp_trp_next_hop(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_next_hop(TR_FILTER_TARGET *target, TR_NAME *val)
 {
-  return tr_ff_cmp_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
-                                     trp_inforec_get_next_hop_port(target->trp_inforec),
-                                     TID_PORT,
-                                     val);
+  return trp_ff_cmp_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
+                                      trp_inforec_get_next_hop_port(target->trp_inforec),
+                                      TID_PORT,
+                                      val);
 }
 
-static TR_NAME *tr_ff_get_trp_next_hop(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_next_hop(TR_FILTER_TARGET *target)
 {
-  return tr_ff_get_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
-                                     trp_inforec_get_next_hop_port(target->trp_inforec));
+  return trp_ff_get_hostname_and_port(trp_inforec_get_next_hop(target->trp_inforec),
+                                      trp_inforec_get_next_hop_port(target->trp_inforec));
 }
 
 /** Handlers for TRP owner_contact field */
-static int tr_ff_cmp_trp_owner_contact(TR_FILTER_TARGET *target, TR_NAME *val)
+static int trp_ff_cmp_owner_contact(TR_FILTER_TARGET *target, TR_NAME *val)
 {
   return tr_name_cmp(trp_inforec_get_owner_contact(target->trp_inforec), val);
 }
 
-static TR_NAME *tr_ff_get_trp_owner_contact(TR_FILTER_TARGET *target)
+static TR_NAME *trp_ff_get_owner_contact(TR_FILTER_TARGET *target)
 {
   return tr_dup_name(trp_inforec_get_owner_contact(target->trp_inforec));
 }
@@ -242,42 +242,54 @@ static TR_NAME *tr_ff_get_trp_owner_contact(TR_FILTER_TARGET *target)
 void trp_filter_init(void)
 {
   /* realm */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "realm", tr_ff_cmp_trp_realm, tr_ff_get_trp_realm);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "realm", tr_ff_cmp_trp_realm, tr_ff_get_trp_realm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "realm", trp_ff_cmp_realm, trp_ff_get_realm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "realm", trp_ff_cmp_realm, trp_ff_get_realm);
 
   /* community */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "comm", tr_ff_cmp_trp_comm, tr_ff_get_trp_comm);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "comm", tr_ff_cmp_trp_comm, tr_ff_get_trp_comm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "comm", trp_ff_cmp_comm, trp_ff_get_comm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "comm", trp_ff_cmp_comm, trp_ff_get_comm);
 
   /* community type */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "comm_type", tr_ff_cmp_trp_comm_type, tr_ff_get_trp_comm_type);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "comm_type", tr_ff_cmp_trp_comm_type, tr_ff_get_trp_comm_type);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "comm_type", trp_ff_cmp_comm_type,
+                              trp_ff_get_comm_type);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "comm_type", trp_ff_cmp_comm_type,
+                              trp_ff_get_comm_type);
 
   /* realm role */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "realm_role", tr_ff_cmp_trp_realm_role, tr_ff_get_trp_realm_role);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "realm_role", tr_ff_cmp_trp_realm_role, tr_ff_get_trp_realm_role);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "realm_role", trp_ff_cmp_realm_role,
+                              trp_ff_get_realm_role);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "realm_role", trp_ff_cmp_realm_role,
+                              trp_ff_get_realm_role);
 
   /* apc */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "apc", tr_ff_cmp_trp_apc, tr_ff_get_trp_apc);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "apc", tr_ff_cmp_trp_apc, tr_ff_get_trp_apc);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "apc", trp_ff_trp_apc, trp_ff_get_apc);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "apc", trp_ff_trp_apc, trp_ff_get_apc);
 
   /* trust_router */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "trust_router", tr_ff_cmp_trp_trust_router, tr_ff_get_trp_trust_router);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "trust_router", tr_ff_cmp_trp_trust_router, tr_ff_get_trp_trust_router);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "trust_router", trp_ff_cmp_trust_router,
+                              trp_ff_get_trust_router);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "trust_router", trp_ff_cmp_trust_router,
+                              trp_ff_get_trust_router);
 
   /* next_hop */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "next_hop", tr_ff_cmp_trp_next_hop, tr_ff_get_trp_next_hop);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "next_hop", tr_ff_cmp_trp_next_hop, tr_ff_get_trp_next_hop);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "next_hop", trp_ff_cmp_next_hop, trp_ff_get_next_hop);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "next_hop", trp_ff_cmp_next_hop, trp_ff_get_next_hop);
 
   /* owner_realm */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "owner_realm", tr_ff_cmp_trp_owner_realm, tr_ff_get_trp_owner_realm);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "owner_realm", tr_ff_cmp_trp_owner_realm, tr_ff_get_trp_owner_realm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "owner_realm", trp_ff_cmp_owner_realm,
+                              trp_ff_get_owner_realm);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "owner_realm", trp_ff_cmp_owner_realm,
+                              trp_ff_get_owner_realm);
 
   /* owner_contact */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "owner_contact", tr_ff_cmp_trp_owner_contact, tr_ff_get_trp_owner_contact);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "owner_contact", tr_ff_cmp_trp_owner_contact, tr_ff_get_trp_owner_contact);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "owner_contact", trp_ff_cmp_owner_contact,
+                              trp_ff_get_owner_contact);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "owner_contact", trp_ff_cmp_owner_contact,
+                              trp_ff_get_owner_contact);
 
   /* info_type */
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "info_type", tr_ff_cmp_trp_info_type, tr_ff_get_trp_info_type);
-  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "info_type", tr_ff_cmp_trp_info_type, tr_ff_get_trp_info_type);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_INBOUND, "info_type", trp_ff_cmp_info_type,
+                              trp_ff_get_info_type);
+  tr_filter_add_field_handler(TR_FILTER_TYPE_TRP_OUTBOUND, "info_type", trp_ff_cmp_info_type,
+                              trp_ff_get_info_type);
 }

--- a/trp/trp_tr_msg.c
+++ b/trp/trp_tr_msg.c
@@ -1,0 +1,849 @@
+/*
+ * Copyright (c) 2012-2018 , JANET(UK)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JANET(UK) nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <openssl/dh.h>
+#include <openssl/crypto.h>
+#include <jansson.h>
+#include <assert.h>
+#include <talloc.h>
+
+#include <tr_apc.h>
+#include <tr_comm.h>
+#include <trp_internal.h>
+#include <mon_internal.h>
+#include <tr_msg.h>
+#include <tr_util.h>
+#include <tr_name_internal.h>
+#include <trust_router/tr_constraint.h>
+#include <trust_router/tr_dh.h>
+#include <tr_debug.h>
+#include <tr_inet_util.h>
+
+/* Prototypes */
+static json_t *tr_msg_encode_trp_upd(void *msg_rep);
+static void *tr_msg_decode_trp_upd(TALLOC_CTX *mem_ctx, json_t *jupdate);
+static json_t *tr_msg_encode_trp_req(void *msg_rep);
+static void *tr_msg_decode_trp_req(TALLOC_CTX *mem_ctx, json_t *jreq);
+
+/* Global handle for message types */
+static struct {
+  TR_MSG_TYPE trp_update;
+  TR_MSG_TYPE trp_request;
+} trp_msg_type = {TR_MSG_TYPE_UNKNOWN, TR_MSG_TYPE_UNKNOWN};
+
+/* Must call this before sending or receiving TRP messages */
+int tr_msg_trp_init(void)
+{
+  int result = 1; /* 1 is success */
+
+  if (trp_msg_type.trp_update == TR_MSG_TYPE_UNKNOWN) {
+    trp_msg_type.trp_update = tr_msg_register_type("trp_update",
+                                                   tr_msg_decode_trp_upd,
+                                                   tr_msg_encode_trp_upd);
+    if (trp_msg_type.trp_update == TR_MSG_TYPE_UNKNOWN) {
+      tr_err("tr_msg_trp_init: unable to register TRP update message type");
+      result = 0;
+    }
+  }
+
+  if (trp_msg_type.trp_request == TR_MSG_TYPE_UNKNOWN) {
+    trp_msg_type.trp_request = tr_msg_register_type("trp_request",
+                                                    tr_msg_decode_trp_req,
+                                                    tr_msg_encode_trp_req);
+    if (trp_msg_type.trp_request == TR_MSG_TYPE_UNKNOWN) {
+      tr_err("tr_msg_trp_init: unable to register TRP request message type");
+      result = 0;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Set the message payload to a TRP request
+ *
+ * Sets the message type
+ */
+void tr_msg_set_trp_req(TR_MSG *msg, TRP_REQ *req)
+{
+  tr_msg_set_msg_type(msg, trp_msg_type.trp_request);
+  tr_msg_set_rep(msg, req);
+}
+
+/**
+ * Get the TRP request from a generic TR_MSG
+ *
+ * Returns null if the message is not a TRP request
+ */
+TRP_REQ *tr_msg_get_trp_req(TR_MSG *msg)
+{
+  if (tr_msg_get_msg_type(msg) == trp_msg_type.trp_request)
+    return (TRP_REQ *) tr_msg_get_rep(msg);
+  return NULL;
+}
+
+/**
+ * Set the message payload to a TRP update
+ *
+ * Sets the message type
+ */
+void tr_msg_set_trp_upd(TR_MSG *msg, TRP_UPD *upd)
+{
+  tr_msg_set_msg_type(msg, trp_msg_type.trp_update);
+  tr_msg_set_rep(msg, upd);
+}
+
+/**
+ * Get the TRP update from a generic TR_MSG
+ *
+ * Returns null if the message is not a TRP update
+ */
+TRP_UPD *tr_msg_get_trp_upd(TR_MSG *msg)
+{
+  if (tr_msg_get_msg_type(msg) == trp_msg_type.trp_update)
+    return (TRP_UPD *) tr_msg_get_rep(msg);
+  return NULL;
+}
+
+/* JSON helpers */
+/* Read attribute attr from msg as an integer. */
+static TRP_RC tr_msg_get_json_integer(json_t *jmsg, const char *attr, int *dest)
+{
+  json_t *obj;
+
+  obj=json_object_get(jmsg, attr);
+  if (obj == NULL) {
+    return TRP_MISSING;
+  }
+  /* check type */
+  if (!json_is_integer(obj)) {
+    return TRP_BADTYPE;
+  }
+
+  (*dest)=json_integer_value(obj);
+  return TRP_SUCCESS;
+}
+
+/* Read attribute attr from msg as a string. Copies string into mem_ctx context so jmsg can
+ * be destroyed safely. Returns nonzero on error. */
+static TRP_RC tr_msg_get_json_string(json_t *jmsg, const char *attr, char **dest, TALLOC_CTX *mem_ctx)
+{
+  json_t *obj;
+
+  obj=json_object_get(jmsg, attr);
+  if (obj == NULL)
+    return TRP_MISSING;
+
+  /* check type */
+  if (!json_is_string(obj))
+    return TRP_BADTYPE;
+
+  *dest=talloc_strdup(mem_ctx, json_string_value(obj));
+  if (*dest==NULL)
+    return TRP_NOMEM;
+
+  return TRP_SUCCESS;
+}
+
+static json_t *hostname_and_port_to_json(TR_NAME *hostname, int port)
+{
+  char *s_hostname = tr_name_strdup(hostname);
+  char *s;
+  json_t *j;
+
+  if (s_hostname == NULL)
+    return NULL;
+
+  s = talloc_asprintf(NULL, "%s:%d", s_hostname, port);
+  free(s_hostname);
+
+  if (s == NULL)
+    return NULL;
+
+  j = json_string(s);
+  talloc_free(s);
+
+  return j;
+}
+
+/* Information records for TRP update msg
+ * requires that jrec already be allocated */
+static TRP_RC tr_msg_encode_inforec_route(json_t *jrec, TRP_INFOREC *rec)
+{
+  json_t *jstr=NULL;
+  json_t *jint=NULL;
+
+  if (rec==NULL)
+    return TRP_BADTYPE;
+
+  if (trp_inforec_get_trust_router(rec)==NULL)
+    return TRP_ERROR;
+
+  jstr=hostname_and_port_to_json(trp_inforec_get_trust_router(rec),
+                                 trp_inforec_get_trust_router_port(rec));
+  if(jstr==NULL)
+    return TRP_NOMEM;
+  json_object_set_new(jrec, "trust_router", jstr);
+
+  jstr=hostname_and_port_to_json(trp_inforec_get_next_hop(rec),
+                                 trp_inforec_get_next_hop_port(rec));
+  if(jstr==NULL)
+    return TRP_NOMEM;
+  json_object_set_new(jrec, "next_hop", jstr);
+
+  jint=json_integer(trp_inforec_get_metric(rec));
+  if(jint==NULL)
+    return TRP_ERROR;
+  json_object_set_new(jrec, "metric", jint);
+
+  jint=json_integer(trp_inforec_get_interval(rec));
+  if(jint==NULL)
+    return TRP_ERROR;
+  json_object_set_new(jrec, "interval", jint);
+
+  return TRP_SUCCESS;
+}
+
+/* returns a json array */
+static json_t *tr_msg_encode_apcs(TR_APC *apcs)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  TR_APC_ITER *iter=tr_apc_iter_new(tmp_ctx);
+  TR_APC *apc=NULL;
+  json_t *jarray=NULL;
+  json_t *jid=NULL;
+
+  if (iter==NULL)
+    goto cleanup;
+
+  jarray=json_array();
+  if (jarray==NULL)
+    goto cleanup;
+
+  for (apc=tr_apc_iter_first(iter, apcs); apc!=NULL; apc=tr_apc_iter_next(iter)) {
+    jid=tr_name_to_json_string(tr_apc_get_id(apc));
+    if ((jid==NULL) || (json_array_append_new(jarray, jid)!=0)) {
+      json_decref(jarray);
+      jarray=NULL;
+      goto cleanup;
+    }
+  }
+
+cleanup:
+  talloc_free(tmp_ctx);
+  return jarray;
+}
+
+static TR_APC *tr_msg_decode_apcs(TALLOC_CTX *mem_ctx, json_t *jarray, TRP_RC *rc)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  size_t ii=0;
+  TR_APC *apc_list=NULL;
+  TR_APC *new=NULL;
+  json_t *jstr=NULL;
+
+  *rc=TRP_ERROR;
+
+  for (ii=0; ii<json_array_size(jarray); ii++) {
+    jstr=json_array_get(jarray, ii);
+    new=tr_apc_new(tmp_ctx);
+    if ((jstr==NULL) || (new==NULL) || (!json_is_string(jstr))) {
+      apc_list=NULL; /* these are all in tmp_ctx, so they'll still get cleaned up */
+      goto cleanup;
+    }
+
+    tr_apc_set_id(new, tr_new_name(json_string_value(jstr)));
+    if (tr_apc_get_id(new)==NULL) {
+      apc_list=NULL; /* these are all in tmp_ctx, so they'll still get cleaned up */
+      goto cleanup;
+    }
+
+    tr_apc_add(apc_list, new);
+  }
+
+  *rc=TRP_SUCCESS;
+
+  if (apc_list!=NULL)
+    talloc_steal(mem_ctx, apc_list);
+
+cleanup:
+  talloc_free(tmp_ctx);
+  return apc_list;
+}
+
+static TRP_RC tr_msg_encode_inforec_comm(json_t *jrec, TRP_INFOREC *rec)
+{
+  json_t *jstr=NULL;
+  json_t *jint=NULL;
+  json_t *japcs=NULL;
+  const char *sconst=NULL;
+  TR_COMM_TYPE commtype=TR_COMM_UNKNOWN;
+
+  if (rec==NULL)
+    return TRP_BADTYPE;
+
+  commtype=trp_inforec_get_comm_type(rec);
+  if (commtype==TR_COMM_UNKNOWN) {
+    tr_notice("tr_msg_encode_inforec_comm: unknown community type.");
+    return TRP_ERROR;
+  }
+  sconst=tr_comm_type_to_str(commtype);
+  if (sconst==NULL)
+    return TRP_ERROR;
+  jstr=json_string(sconst);
+  if(jstr==NULL)
+    return TRP_ERROR;
+  json_object_set_new(jrec, "type", jstr);
+
+  sconst=tr_realm_role_to_str(trp_inforec_get_role(rec));
+  if (sconst==NULL) {
+    tr_notice("tr_msg_encode_inforec_comm: unknown realm role.");
+    return TRP_ERROR;
+  }
+  jstr=json_string(sconst);
+  if(jstr==NULL)
+    return TRP_ERROR;
+  json_object_set_new(jrec, "role", jstr);
+
+  japcs=tr_msg_encode_apcs(trp_inforec_get_apcs(rec));
+  if (japcs==NULL) {
+    tr_notice("tr_msg_encode_inforec_comm: error encoding APCs.");
+    return TRP_ERROR;
+  }
+  json_object_set_new(jrec, "apcs", japcs);
+
+
+  if (trp_inforec_get_owner_realm(rec)!=NULL) {
+    jstr=tr_name_to_json_string(trp_inforec_get_owner_realm(rec));
+    if(jstr==NULL)
+      return TRP_ERROR;
+    json_object_set_new(jrec, "owner_realm", jstr);
+  }
+
+  if (trp_inforec_get_owner_contact(rec)!=NULL) {
+    jstr=tr_name_to_json_string(trp_inforec_get_owner_contact(rec));
+    if(jstr==NULL)
+      return TRP_ERROR;
+    json_object_set_new(jrec, "owner_contact", jstr);
+  }
+
+  json_object_set(jrec, "provenance", trp_inforec_get_provenance(rec));
+
+  jint=json_integer(trp_inforec_get_interval(rec));
+  if(jint==NULL)
+    return TRP_ERROR;
+  json_object_set_new(jrec, "interval", jint);
+
+  return TRP_SUCCESS;
+}
+
+static json_t *tr_msg_encode_inforec(TRP_INFOREC *rec)
+{
+  json_t *jrec=NULL;
+  json_t *jstr=NULL;
+
+  if ((rec==NULL) || (trp_inforec_get_type(rec)==TRP_INFOREC_TYPE_UNKNOWN))
+    return NULL;
+
+  jrec=json_object();
+  if (jrec==NULL)
+    return NULL;
+
+  jstr=json_string(trp_inforec_type_to_string(trp_inforec_get_type(rec)));
+  if (jstr==NULL) {
+    json_decref(jrec);
+    return NULL;
+  }
+  json_object_set_new(jrec, "record_type", jstr);
+
+  switch (rec->type) {
+  case TRP_INFOREC_TYPE_ROUTE:
+    if (TRP_SUCCESS!=tr_msg_encode_inforec_route(jrec, rec)) {
+      json_decref(jrec);
+      return NULL;
+    }
+    break;
+  case TRP_INFOREC_TYPE_COMMUNITY:
+    if (TRP_SUCCESS!=tr_msg_encode_inforec_comm(jrec, rec)) {
+      json_decref(jrec);
+      return NULL;
+    }
+    break;
+  default:
+    json_decref(jrec);
+    return NULL;
+  }
+  return jrec;
+}
+
+static TRP_RC tr_msg_decode_trp_inforec_route(json_t *jrecord, TRP_INFOREC *rec)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  TRP_RC rc=TRP_ERROR;
+  char *s=NULL;
+  TR_NAME *name;
+  char *hostname;
+  int port;
+  int num=0;
+
+  /* get the trust router */
+  rc=tr_msg_get_json_string(jrecord, "trust_router", &s, tmp_ctx);
+  if (rc != TRP_SUCCESS)
+    goto cleanup;
+
+  hostname = tr_parse_host(tmp_ctx, s, &port);
+  if ((NULL == hostname)
+      || (NULL == (name = tr_new_name(hostname)))
+      || (port < 0)) {
+    rc = TRP_ERROR;
+    goto cleanup;
+  }
+  talloc_free(s); s=NULL;
+  talloc_free(hostname);
+
+  if (port == 0)
+    port = TRP_PORT;
+
+  if (TRP_SUCCESS!= trp_inforec_set_trust_router(rec, name, port)) {
+    rc=TRP_ERROR;
+    goto cleanup;
+  }
+
+  /* Now do the next hop. If it's not present, use the trust_router for backward
+   * compatibility */
+  switch(tr_msg_get_json_string(jrecord, "next_hop", &s, tmp_ctx)) {
+    case TRP_SUCCESS:
+      /* we got a next_hop field */
+      hostname = tr_parse_host(tmp_ctx, s, &port);
+      if ((hostname == NULL)
+          || (NULL == (name = tr_new_name(hostname)))
+          || (port < 0)) {
+        rc = TRP_ERROR;
+        goto cleanup;
+      }
+      break;
+
+    case TRP_MISSING:
+      /* no next_hop field; use the trust router */
+      name = tr_dup_name(trp_inforec_get_trust_router(rec));
+      if (name == NULL) {
+        rc = TRP_ERROR;
+        goto cleanup;
+      }
+      break;
+
+    default:
+      /* something went wrong */
+      rc = TRP_ERROR;
+      goto cleanup;
+  }
+  talloc_free(s); s=NULL;
+
+  if (port == 0)
+    port = TID_PORT;
+
+  if (TRP_SUCCESS!= trp_inforec_set_next_hop(rec, name, port)) {
+    rc=TRP_ERROR;
+    goto cleanup;
+  }
+
+  rc=tr_msg_get_json_integer(jrecord, "metric", &num);
+  if ((rc != TRP_SUCCESS) || (TRP_SUCCESS!=trp_inforec_set_metric(rec,num)))
+    goto cleanup;
+
+  rc=tr_msg_get_json_integer(jrecord, "interval", &num);
+  if ((rc != TRP_SUCCESS) || (TRP_SUCCESS!=trp_inforec_set_interval(rec,num)))
+    goto cleanup;
+
+cleanup:
+  talloc_free(tmp_ctx);
+  return rc;
+}
+
+static TRP_RC tr_msg_decode_trp_inforec_comm(json_t *jrecord, TRP_INFOREC *rec)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  TRP_RC rc=TRP_ERROR;
+  char *s=NULL;
+  int num=0;
+  TR_APC *apcs=NULL;
+
+  rc=tr_msg_get_json_string(jrecord, "type", &s, tmp_ctx);
+  if (rc != TRP_SUCCESS)
+    goto cleanup;
+  if (TRP_SUCCESS!=trp_inforec_set_comm_type(rec, tr_comm_type_from_str(s))) {
+    rc=TRP_ERROR;
+    goto cleanup;
+  }
+  talloc_free(s); s=NULL;
+
+  rc=tr_msg_get_json_string(jrecord, "role", &s, tmp_ctx);
+  if (rc != TRP_SUCCESS)
+    goto cleanup;
+  if (TRP_SUCCESS!=trp_inforec_set_role(rec, tr_realm_role_from_str(s))) {
+    rc=TRP_ERROR;
+    goto cleanup;
+  }
+  talloc_free(s); s=NULL;
+
+  apcs=tr_msg_decode_apcs(rec, json_object_get(jrecord, "apcs"), &rc);
+  if (rc!=TRP_SUCCESS) {
+    rc=TRP_ERROR;
+    goto cleanup;
+  }
+  trp_inforec_set_apcs(rec, apcs);
+
+  rc=tr_msg_get_json_integer(jrecord, "interval", &num);
+  tr_debug("tr_msg_decode_trp_inforec_comm: interval=%u", num);
+  if ((rc != TRP_SUCCESS) || (TRP_SUCCESS!=trp_inforec_set_interval(rec,num)))
+    goto cleanup;
+
+  trp_inforec_set_provenance(rec, json_object_get(jrecord, "provenance"));
+
+  /* optional */
+  rc=tr_msg_get_json_string(jrecord, "owner_realm", &s, tmp_ctx);
+  if (rc == TRP_SUCCESS) {
+    if (TRP_SUCCESS!=trp_inforec_set_owner_realm(rec, tr_new_name(s))) {
+      rc=TRP_ERROR;
+      goto cleanup;
+    }
+    if (s!=NULL) {
+      talloc_free(s);
+      s=NULL;
+    }
+  }
+
+  rc=tr_msg_get_json_string(jrecord, "owner_contact", &s, tmp_ctx);
+  if (rc == TRP_SUCCESS) {
+    if (TRP_SUCCESS!=trp_inforec_set_owner_contact(rec, tr_new_name(s))) {
+      rc=TRP_ERROR;
+      goto cleanup;
+    }
+    if (s!=NULL) {
+      talloc_free(s);
+      s=NULL;
+    }
+  }
+
+cleanup:
+  talloc_free(tmp_ctx);
+  return rc;
+}
+
+/* decode a single record */
+static TRP_INFOREC *tr_msg_decode_trp_inforec(TALLOC_CTX *mem_ctx, json_t *jrecord)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  TRP_INFOREC_TYPE rectype;
+  TRP_INFOREC *rec=NULL;
+  TRP_RC rc=TRP_ERROR;
+  char *s=NULL;
+
+  if (TRP_SUCCESS!=tr_msg_get_json_string(jrecord, "record_type", &s, tmp_ctx))
+    goto cleanup;
+
+  rectype=trp_inforec_type_from_string(s);
+  talloc_free(s); s=NULL;
+
+  rec=trp_inforec_new(tmp_ctx, rectype);
+  if (rec==NULL) {
+    rc=TRP_NOMEM;
+    goto cleanup;
+  }
+
+  tr_debug("tr_msg_decode_trp_inforec: '%s' record found.", trp_inforec_type_to_string(rec->type));
+
+  switch(trp_inforec_get_type(rec)) {
+  case TRP_INFOREC_TYPE_ROUTE:
+    rc=tr_msg_decode_trp_inforec_route(jrecord, rec);
+    break;
+  case TRP_INFOREC_TYPE_COMMUNITY:
+    rc=tr_msg_decode_trp_inforec_comm(jrecord, rec);
+    break;
+  default:
+    rc=TRP_UNSUPPORTED;
+    goto cleanup;
+  }
+
+  talloc_steal(mem_ctx, rec);
+  rc=TRP_SUCCESS;
+
+cleanup:
+  if (rc != TRP_SUCCESS) {
+    trp_inforec_free(rec);
+    rec=NULL;
+  }
+  talloc_free(tmp_ctx);
+  return rec;
+}
+
+/* TRP update msg */
+static json_t *tr_msg_encode_trp_upd(void *msg_rep)
+{
+  TRP_UPD *update = (TRP_UPD *) msg_rep;
+  json_t *jupdate=NULL;
+  json_t *jrecords=NULL;
+  json_t *jrec=NULL;
+  json_t *jstr=NULL;
+  TRP_INFOREC *rec;
+  char *s=NULL;
+
+  if (update==NULL)
+    return NULL;
+
+  jupdate=json_object();
+  if (jupdate==NULL)
+    return NULL;
+
+  s=tr_name_strdup(trp_upd_get_comm(update));
+  if (s==NULL) {
+    json_decref(jupdate);
+    return NULL;
+  }
+  jstr=json_string(s);
+  free(s);s=NULL;
+  if(jstr==NULL) {
+    json_decref(jupdate);
+    return NULL;
+  }
+  json_object_set_new(jupdate, "community", jstr);
+
+  s=tr_name_strdup(trp_upd_get_realm(update));
+  if (s==NULL) {
+    json_decref(jupdate);
+    return NULL;
+  }
+  jstr=json_string(s);
+  free(s);s=NULL;
+  if(jstr==NULL) {
+    json_decref(jupdate);
+    return NULL;
+  }
+  json_object_set_new(jupdate, "realm", jstr);
+
+  jrecords=json_array();
+  if (jrecords==NULL) {
+    json_decref(jupdate);
+    return NULL;
+  }
+  json_object_set_new(jupdate, "records", jrecords); /* jrecords now a "borrowed" reference */
+  for (rec=trp_upd_get_inforec(update); rec!=NULL; rec=trp_inforec_get_next(rec)) {
+    tr_debug("tr_msg_encode_trp_upd: encoding inforec.");
+    jrec=tr_msg_encode_inforec(rec);
+    if (jrec==NULL) {
+      json_decref(jupdate); /* also decs jrecords and any elements */
+      return NULL;
+    }
+    if (0!=json_array_append_new(jrecords, jrec)) {
+      json_decref(jupdate); /* also decs jrecords and any elements */
+      json_decref(jrec); /* this one did not get added so dec explicitly */
+      return NULL;
+    }
+  }
+
+  return jupdate;
+}
+
+/* Creates a linked list of records in the msg->body talloc context.
+ * An error will be returned if any unparseable records are encountered.
+ */
+static void *tr_msg_decode_trp_upd(TALLOC_CTX *mem_ctx, json_t *jupdate)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  json_t *jrecords=NULL;
+  size_t ii=0;
+  TRP_UPD *update=NULL;
+  TRP_INFOREC *new_rec=NULL;
+  TRP_INFOREC *list_tail=NULL;
+  char *s=NULL;
+  TR_NAME *name;
+  TRP_RC rc=TRP_ERROR;
+
+  update=trp_upd_new(tmp_ctx);
+  if (update==NULL) {
+    rc=TRP_NOMEM;
+    goto cleanup;
+  }
+
+  rc=tr_msg_get_json_string(jupdate, "community", &s, tmp_ctx);
+  if (rc != TRP_SUCCESS) {
+    tr_debug("tr_msg_decode_trp_upd: no community in TRP update message.");
+    rc=TRP_NOPARSE;
+    goto cleanup;
+  }
+  name=tr_new_name(s);
+  if (name==NULL) {
+    tr_debug("tr_msg_decode_trp_upd: could not allocate community name.");
+    rc=TRP_NOMEM;
+    goto cleanup;
+  }
+  talloc_free(s); s=NULL;
+  trp_upd_set_comm(update, name);
+
+  rc=tr_msg_get_json_string(jupdate, "realm", &s, tmp_ctx);
+  if (rc != TRP_SUCCESS) {
+    tr_debug("tr_msg_decode_trp_upd: no realm in TRP update message.");
+    rc=TRP_NOPARSE;
+    goto cleanup;
+  }
+  name=tr_new_name(s);
+  if (name==NULL) {
+    tr_debug("tr_msg_decode_trp_upd: could not allocate realm name.");
+    rc=TRP_NOMEM;
+    goto cleanup;
+  }
+  talloc_free(s); s=NULL;
+  trp_upd_set_realm(update, name);
+
+  jrecords=json_object_get(jupdate, "records");
+  if ((jrecords==NULL) || (!json_is_array(jrecords))) {
+    rc=TRP_NOPARSE;
+    goto cleanup;
+  }
+
+  tr_debug("tr_msg_decode_trp_upd: found %d records", json_array_size(jrecords));
+  /* process the array */
+  for (ii=0; ii<json_array_size(jrecords); ii++) {
+    new_rec=tr_msg_decode_trp_inforec(update, json_array_get(jrecords, ii));
+    if (new_rec==NULL) {
+      rc=TRP_NOPARSE;
+      goto cleanup;
+    }
+
+    if (list_tail==NULL)
+      trp_upd_set_inforec(update, new_rec); /* first is a special case */
+    else
+      trp_inforec_set_next(list_tail, new_rec);
+
+    list_tail=new_rec;
+  }
+
+  /* Succeeded. Move new allocations into the correct talloc context */
+  talloc_steal(mem_ctx, update);
+  rc=TRP_SUCCESS;
+
+cleanup:
+  talloc_free(tmp_ctx);
+  if (rc!=TRP_SUCCESS)
+    return NULL;
+  return update;
+}
+
+static json_t *tr_msg_encode_trp_req(void *msg_rep)
+{
+  TRP_REQ *req = (TRP_REQ *) msg_rep;
+  json_t *jbody=NULL;
+  json_t *jstr=NULL;
+  char *s=NULL;
+
+  if (req==NULL)
+    return NULL;
+
+  jbody=json_object();
+  if (jbody==NULL)
+    return NULL;
+
+  if ((NULL==trp_req_get_comm(req))
+     || (NULL==trp_req_get_realm(req))) {
+    json_decref(jbody);
+    return NULL;
+  }
+
+  s=tr_name_strdup(trp_req_get_comm(req)); /* ensures null termination */
+  if (s==NULL) {
+    json_decref(jbody);
+    return NULL;
+  }
+  jstr=json_string(s);
+  free(s); s=NULL;
+  if (jstr==NULL) {
+    json_decref(jbody);
+    return NULL;
+  }
+  json_object_set_new(jbody, "community", jstr);
+
+  s=tr_name_strdup(trp_req_get_realm(req)); /* ensures null termination */
+  if (s==NULL) {
+    json_decref(jbody);
+    return NULL;
+  }
+  jstr=json_string(s);
+  free(s); s=NULL;
+  if (jstr==NULL) {
+    json_decref(jbody);
+    return NULL;
+  }
+  json_object_set_new(jbody, "realm", jstr);
+
+  return jbody;
+}
+
+static void *tr_msg_decode_trp_req(TALLOC_CTX *mem_ctx, json_t *jreq)
+{
+  TALLOC_CTX *tmp_ctx=talloc_new(NULL);
+  TRP_REQ *req=NULL;
+  char *s=NULL;
+  TRP_RC rc=TRP_ERROR;
+
+  /* check message type and body type for agreement */
+  req=trp_req_new(tmp_ctx);
+  if (req==NULL) {
+    rc=TRP_NOMEM;
+    goto cleanup;
+  }
+
+  rc=tr_msg_get_json_string(jreq, "community", &s, tmp_ctx);
+  if (rc!=TRP_SUCCESS)
+    goto cleanup;
+  trp_req_set_comm(req, tr_new_name(s));
+  talloc_free(s); s=NULL;
+
+  rc=tr_msg_get_json_string(jreq, "realm", &s, tmp_ctx);
+  if (rc!=TRP_SUCCESS)
+    goto cleanup;
+  trp_req_set_realm(req, tr_new_name(s));
+  talloc_free(s); s=NULL;
+
+  rc=TRP_SUCCESS;
+  talloc_steal(mem_ctx, req);
+
+cleanup:
+  talloc_free(tmp_ctx);
+  if (rc!=TRP_SUCCESS)
+    return NULL;
+  return req;
+}

--- a/trp/trpc.c
+++ b/trp/trpc.c
@@ -65,7 +65,9 @@ TRPC_INSTANCE *trpc_new (TALLOC_CTX *mem_ctx)
       trpc=NULL;
     } else
       talloc_set_destructor((void *)trpc, trpc_destructor);
-    
+
+    tr_msg_trp_init(); /* ensure TR_MSG can handle TRP messages */
+    trp_filter_init(); /* ensure we can filter on TRP message fields */
   }
   return trpc;
 }
@@ -205,7 +207,7 @@ TRP_RC trpc_connect(TRPC_INSTANCE *trpc)
 }
 
 /* simple function, based on tidc_send_req */
-TRP_RC trpc_send_msg (TRPC_INSTANCE *trpc, 
+TRP_RC trpc_send_msg (TRPC_INSTANCE *trpc,
                       const char *msg_content)
 {
   int err=0;
@@ -214,7 +216,7 @@ TRP_RC trpc_send_msg (TRPC_INSTANCE *trpc,
   /* Send the request over the connection */
   if (err = gsscon_write_encrypted_token(trp_connection_get_fd(trpc_get_conn(trpc)),
                                          *trp_connection_get_gssctx(trpc_get_conn(trpc)),
-                                         msg_content, 
+                                         msg_content,
                                          strlen(msg_content))) {
     tr_err( "trpc_send_msg: Error sending message over connection.");
     rc=TRP_ERROR;

--- a/trp/trpc.c
+++ b/trp/trpc.c
@@ -66,7 +66,7 @@ TRPC_INSTANCE *trpc_new (TALLOC_CTX *mem_ctx)
     } else
       talloc_set_destructor((void *)trpc, trpc_destructor);
 
-    tr_msg_trp_init(); /* ensure TR_MSG can handle TRP messages */
+    trp_tr_msg_init(); /* ensure TR_MSG can handle TRP messages */
     trp_filter_init(); /* ensure we can filter on TRP message fields */
   }
   return trpc;

--- a/trust_router.spec
+++ b/trust_router.spec
@@ -1,7 +1,7 @@
 %global optflags %{optflags} -Wno-parentheses
 %{!?_release_number: %define _release_number 1}
 Name:           trust_router
-Version:        3.4.1~2
+Version:        3.4.1~3
 Release:        %{_release_number}%{?dist}
 Summary:        Moonshot Trust Router
 

--- a/trust_router.spec
+++ b/trust_router.spec
@@ -1,7 +1,7 @@
 %global optflags %{optflags} -Wno-parentheses
 %{!?_release_number: %define _release_number 1}
 Name:           trust_router
-Version:        3.4.1~3
+Version:        3.4.1
 Release:        %{_release_number}%{?dist}
 Summary:        Moonshot Trust Router
 


### PR DESCRIPTION
This pull request allows `libtr_tid` to build without including large amounts of unrelated code. To do this, it refactors `tr_msg.c` and `tr_filter.c` to separate TID, TRP, and MON dependencies. It then rearranges linking in `Makefile.am` so that the `$(tid_srcs)` group can be used without needing large amounts of unrelated code.